### PR TITLE
Make the README prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ standard debugging tools.
 The BMC must first be put into debug mode to allow access to the
 relevant GPIOs:
 
-ipmitool -H <host> -U <username> -P <password> raw 0x3a 0x01
+`ipmitool -H <host> -U <username> -P <password> raw 0x3a 0x01`
 
 Usage is straight forward:
 
+```
 $ ./pdbg --help
+
 Usage: ./pdbg [options] command ...
 
  Options:
@@ -37,8 +39,9 @@ Usage: ./pdbg [options] command ...
         stopchip
         startchip <threads>
         threadstatus
-
+```
 ### Probe chip and processor numbers
+```
 $ ./pdbg probe
 
 Probing for valid processors...
@@ -65,29 +68,41 @@ Probing for valid processors...
                 Chiplet-ID 12 present
                 Chiplet-ID 13 present
                 Chiplet-ID 14 present
+```
 
 Chiplet-IDs are core/chip numbers which should be passed as arguments
-to -c when performing operations such as getgpr that operate on
-particular cores. Processor-IDs should be passed as arguments to -p to
+to `-c` when performing operations such as getgpr that operate on
+particular cores. Processor-IDs should be passed as arguments to `-p` to
 operate on different processor chips.
 
 ### Read SCOM register
+```
 $ ./pdbg getscom 0xf000f
+
 0xf000f: 0x220ea04980000000
+```
 
 ### Write SCOM register on secondary processor
-$ ./pdbg -p 3 putscom 0x8013c02 0x0
+`$ ./pdbg -p 3 putscom 0x8013c02 0x0`
 
 ### Read GPR on core/chip 2
+```
 $ ./pdbg -c 2 getgpr 2
+
 r2 = 0xc00000000174fd00
+```
 
 ### Read SPR 8 (LR) on core/chip 2
+```
 $ ./pdbg -c 2 getspr 8
+
 spr8 = 0xc000000000011824
+```
 
 ### Stop thread execution on core/chip 2
+```
 $ ./pdbg -c 2 stopchip
+
 Previously active thread mask: 0x00
 Thread 0 is STOPPED
 Thread 1 is STOPPED
@@ -97,9 +112,12 @@ Thread 4 is STOPPED
 Thread 5 is STOPPED
 Thread 6 is STOPPED
 Thread 7 is STOPPED
+```
 
 ### Get execution state on core/chip 2
+```
 $ ./pdbg -c 2 threadstatus
+
 Thread 0 is STOPPED
 Thread 1 is STOPPED
 Thread 2 is STOPPED
@@ -108,13 +126,16 @@ Thread 4 is STOPPED
 Thread 5 is STOPPED
 Thread 6 is STOPPED
 Thread 7 is STOPPED
+```
 
 ### Restart thread execution on core/chip 2
 
 The first parameter is the active thread mask returned when stopping
 the chip.
 
+```
 $ ./pdbg -c 2 startchip 0x00
+
 Thread 0 is RUNNING
 Thread 1 is RUNNING
 Thread 2 is RUNNING
@@ -123,3 +144,4 @@ Thread 4 is RUNNING
 Thread 5 is RUNNING
 Thread 6 is RUNNING
 Thread 7 is RUNNING
+```


### PR DESCRIPTION
The README doesn't look great in markdown, so wrap the examples in code blocks, with a newline separating command and output.

Signed-off-by: Russell Currey <ruscur@russell.cc>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/pdbg/6)
<!-- Reviewable:end -->
