### PR TITLE
bmcfsi: Report read response CRC errors to stderr

### DIFF
--- a/libpdbg/bmcfsi.c
+++ b/libpdbg/bmcfsi.c
@@ -331,7 +331,7 @@ static enum fsi_result fsi_read_resp(uint64_t *result, int len)
 	}
 
 	if (crc != 0) {
-		printf("CRC error: 0x%llx\n", resp);
+		fprintf(stderr, "CRC error: 0x%llx\n", resp);
 		return FSI_MERR_C;
 	}
 


### PR DESCRIPTION
Putting CRC error messages into stderr helps with scripting that parses
the output of pdbg.

Signed-off-by: Xo Wang <xow@google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/pdbg/11)
<!-- Reviewable:end -->
