### PR TITLE
Fix CFAM address computing for OpenFSI.

### DIFF
--- a/libpdbg/bmcfsi.c
+++ b/libpdbg/bmcfsi.c
@@ -247,7 +247,7 @@ static uint64_t fsi_abs_ar(uint32_t addr, int read)
 	/* Reformat the address. I'm not sure I fully understand this
 	 * yet but we basically shift the bottom byte and add 0b01
 	 * (for the write word?) */
-       	addr = ((addr & 0x1fff00) | ((addr & 0xff) << 2)) << 1;
+       	addr = ((addr & 0x1ffc00) | ((addr & 0x3ff) << 2)) << 1;
 	addr |= 0x3;
 	addr |= slave_id << 26;
 	addr |= (0x8ULL | !!(read)) << 22;

--- a/libpdbg/kernel.c
+++ b/libpdbg/kernel.c
@@ -79,7 +79,7 @@ static int kernel_getscom(struct target *target, uint64_t addr, uint64_t *value)
 static int kernel_fsi_getcfam(struct target *target, uint64_t addr64, uint64_t *value)
 {
 	int rc;
-	uint32_t addr = (addr64 & 0xffff00) | ((addr64 & 0xff) << 2);
+	uint32_t addr = (addr64 & 0x7ffc00) | ((addr64 & 0x3ff) << 2);
 
 	rc = lseek(fsi_fd, addr, SEEK_SET);
 	if (rc < 0) {
@@ -103,7 +103,7 @@ static int kernel_fsi_getcfam(struct target *target, uint64_t addr64, uint64_t *
 static int kernel_fsi_putcfam(struct target *target, uint64_t addr64, uint64_t data)
 {
 	int rc;
-	uint32_t addr = (addr64 & 0xffff00) | ((addr64 & 0xff) << 2);
+	uint32_t addr = (addr64 & 0x7ffc00) | ((addr64 & 0x3ff) << 2);
 
 	rc = lseek(fsi_fd, addr, SEEK_SET);
 	if (rc < 0) {


### PR DESCRIPTION
Modified the computing of OpenFSI CFAM address masking
for putcfam and getcfam.

Signed-off-by: Dinesh Chinari <chinari@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/pdbg/16)
<!-- Reviewable:end -->
