### PR TITLE
Rework generation of .dtb.o

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -61,10 +61,5 @@ p9r-fsi.dtb.o: p9r-fsi.dts p9-fsi.dtsi
 p9z-fsi.dtb.o: p9z-fsi.dts p9-fsi.dtsi
 %.dtb.o: %.dts
 	dtc -i$(dir $@) -I dts $< -O dtb > $@.tmp
-
-# We need to align the output as some processor/kernel
-# combinations can't deal with the alignment errors when
-# unflattening the device-tree
-	dd if=$@.tmp of=$@ ibs=16 conv=sync
-	rm $@.tmp
-	$(OBJCOPY) -I binary -O @ARCH_FF@ $@ $@
+	symbol_prefix=`echo $@ | sed 's%\.%_%g; s%-%_%g'` ; \
+	cat template.S | sed "s%SYMBOL_PREFIX%$${symbol_prefix}%g; s%FILENAME%$@.tmp%g" | $(CC) -xassembler - -c -o $@

--- a/configure.ac
+++ b/configure.ac
@@ -8,15 +8,4 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile])
 AC_LANG(C)
-AC_SUBST([ARCH_FF])
-AC_CHECK_TOOL([OBJDUMP], [objdump])
-AC_CHECK_TOOL([OBJCOPY], [objcopy])
-AC_SUBST([OBJCOPY])
-AC_COMPILE_IFELSE(
-	[AC_LANG_SOURCE([[]])],
-	ARCH_FF=$(${OBJDUMP} -f conftest.$OBJEXT |
-	sed -ne "s/.*file format //p" -e "s/.*architecture: \(.*\),.*/\1/p" |
-	tr "\n" " " |
-	sed -e "s/ / -B /"),
-	AC_MSG_FAILURE([Unable to determine architecture output file format]))
 AC_OUTPUT

--- a/template.S
+++ b/template.S
@@ -1,0 +1,10 @@
+.section .data
+_binary_SYMBOL_PREFIX_start:
+.incbin "FILENAME"
+.align 4
+_binary_SYMBOL_PREFIX_end:
+_binary_SYMBOL_PREFIX_size:
+	.long	_binary_SYMBOL_PREFIX_end - _binary_SYMBOL_PREFIX_start
+.globl _binary_SYMBOL_PREFIX_start
+.globl _binary_SYMBOL_PREFIX_end
+.globl _binary_SYMBOL_PREFIX_size


### PR DESCRIPTION
The .dtb.o files are currently generated by compiling the .dts into
.dtb, and then making a pass of objcopy to turn them into an ELF file
that can be linked with the rest of pdbg.

Unfortunately, this objcopy logic doesn't work on all platforms,
because it doesn't generate an object file with the correct ABI
flags. For example, on mips32r6, it fails to build with:

mipsel-buildroot-linux-gnu/bin/ld: fake.dtb.o: warning: linking abicalls files with non-abicalls files
mipsel-buildroot-linux-gnu/bin/ld: fake.dtb.o: linking -mnan=legacy module with previous -mnan=2008 modules
mipsel-buildroot-linux-gnu/bin/ld: failed to merge target specific data of file fake.dtb.o
mipsel-buildroot-linux-gnu/bin/ld: p8-fsi.dtb.o: warning: linking abicalls files with non-abicalls files

In order to fix this, we want to generate a proper object file with
gcc instead of playing tricks with objcopy, and this is what this
commit implement.

We have a template.S file, which gets sed'ed on the fly to point to
the right file / use the right symbol name, and then is fed to gcc.

This allows to remove all the objdump/objcopy logic from the
configure.ac script as well.

This fixes build issues of pdbg seems inside the Buildroot project:

  http://autobuild.buildroot.net/?reason=pdbg-77158819158d1d7053a737ac090d04fdfbfe9265

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
---
Note: this has only been build tested, so please do some runtime
testing before applying!

Note 2: there is possibly a better way than doing the horrible sed
logic I came up with, suggestions welcome.