### PR TITLE
template.S: fix to build on architecture with non-empty __USER_LABEL_…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -62,4 +62,4 @@ p9z-fsi.dtb.o: p9z-fsi.dts p9-fsi.dtsi
 %.dtb.o: %.dts
 	dtc -i$(dir $@) -I dts $< -O dtb > $@.tmp
 	symbol_prefix=`echo $@ | tr '.-' '_'` ; \
-	sed "s%SYMBOL_PREFIX%$${symbol_prefix}%g; s%FILENAME%$@.tmp%g" $(top_srcdir)/template.S | $(CC) -xassembler - -c -o $@
+	sed "s%SYMBOL_PREFIX%$${symbol_prefix}%g; s%FILENAME%$@.tmp%g" $(top_srcdir)/template.S | $(CPP) - | $(CC) -xassembler - -c -o $@

--- a/template.S
+++ b/template.S
@@ -1,10 +1,18 @@
+#ifdef __USER_LABEL_PREFIX__
+#define CONCAT1(a, b) CONCAT2(a, b)
+#define CONCAT2(a, b) a ## b
+#define SYM(x) CONCAT1 (__USER_LABEL_PREFIX__, x)
+#else
+#define SYM(x) x
+#endif
+
 .section .data
-_binary_SYMBOL_PREFIX_start:
+SYM(_binary_SYMBOL_PREFIX_start):
 .incbin "FILENAME"
 .align 4
-_binary_SYMBOL_PREFIX_end:
-_binary_SYMBOL_PREFIX_size:
-	.long	_binary_SYMBOL_PREFIX_end - _binary_SYMBOL_PREFIX_start
-.globl _binary_SYMBOL_PREFIX_start
-.globl _binary_SYMBOL_PREFIX_end
-.globl _binary_SYMBOL_PREFIX_size
+SYM(_binary_SYMBOL_PREFIX_end):
+SYM(_binary_SYMBOL_PREFIX_size):
+	.long	SYM(_binary_SYMBOL_PREFIX_end) - SYM(_binary_SYMBOL_PREFIX_start)
+.globl SYM(_binary_SYMBOL_PREFIX_start)
+.globl SYM(_binary_SYMBOL_PREFIX_end)
+.globl SYM(_binary_SYMBOL_PREFIX_size)


### PR DESCRIPTION
…PREFIX__

Blackfin has a non-empty __USER_LABEL_PREFIX__, which means that a
symbol called "foo" in C must be named "_foo" in assembler.

Interestingly, it seems like "$(CC) -xassembler - -c" doesn't pass the
input source file through the C preprocessor, so we do this
explicitly.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>