### PR TITLE
putmem: Fix Floating point exception issue

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -90,6 +90,9 @@ static int putmem(uint64_t addr, struct mem_flags flags)
 	progress_init();
 	do {
 		read_size = read(STDIN_FILENO, buf, PUTMEM_BUF_SIZE);
+		if (read_size <= 0)
+			break;
+
 		if (__adu_putmem(adu_target, addr, buf, read_size, flags.ci)) {
 			rc = 0;
 			printf("Unable to write memory.\n");

--- a/src/progress.c
+++ b/src/progress.c
@@ -51,6 +51,9 @@ void progress_tick(uint64_t cur, uint64_t end)
 	uint64_t pcent;
 	double sec;
 
+	if (end == 0)
+		return;
+
 	pcent = (cur * 100) / end;
 	if (progress_pcent == pcent && cur < progress_n_upd &&
 	    cur < end)


### PR DESCRIPTION
Validate read() before calling __adu_putmem().
Also check end size in progress_tick().

Signed-off-by: Vasant Hegde <hegdevasant@linux.vnet.ibm.com>