### PR TITLE
src/thread.c: include endian.h

### DIFF
--- a/src/thread.c
+++ b/src/thread.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <endian.h>
 
 #include <libpdbg.h>
 


### PR DESCRIPTION
endian.h is needed for be64oh otherwise build with musl fails on:

src/thread.c: In function 'flip_endian':
src/thread.c:49:9: error: implicit declaration of function 'be64toh' [-Werror=implicit-function-declaration]
  return be64toh(v);

Fixes:
 - http://autobuild.buildroot.org/results/81b1107bdb06250e1a7837506aec0c9762e771c5

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>