### PR TITLE
libpdbg: fix build with system libfdt

### DIFF
--- a/libpdbg/device.c
+++ b/libpdbg/device.c
@@ -18,8 +18,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include "target.h"
-#include <libfdt/libfdt.h>
-#include <libfdt/libfdt_internal.h>
+#include <libfdt.h>
 #include <ccan/list/list.h>
 #include <ccan/short_types/short_types.h>
 #include <ccan/str/str.h>

--- a/libpdbg/target.c
+++ b/libpdbg/target.c
@@ -4,7 +4,7 @@
 #include <inttypes.h>
 #include <assert.h>
 #include <ccan/list/list.h>
-#include <libfdt/libfdt.h>
+#include <libfdt.h>
 
 #include "bitutils.h"
 #include "hwunit.h"


### PR DESCRIPTION
- drop superfluous include
- include libfdt.h from include directory, not from libfdt subdirectory,  which means the local copy due -I.

Signed-off-by: Dan Horák <dan@danny.cz>