### PR TITLE
Fix build with -DNDEBUG

### DIFF
--- a/libpdbg/adu.c
+++ b/libpdbg/adu.c
@@ -15,6 +15,7 @@
  */
 #include <stdio.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
 
@@ -107,7 +108,7 @@ uint8_t blog2(uint8_t x)
 	case 64:
 		return 6;
 	default:
-		assert(0);
+		abort();
 	}
 }
 

--- a/libpdbg/cfam.c
+++ b/libpdbg/cfam.c
@@ -320,7 +320,8 @@ static int cfam_hmfsi_probe(struct pdbg_target *target)
 	int rc;
 
 	/* Enable the port in the upstream control register */
-	assert(!(pdbg_target_u32_property(target, "port", &port)));
+	rc = pdbg_target_u32_property(target, "port", &port);
+	assert(!rc);
 	fsi_read(fsi_parent, 0x3404, &value);
 	value |= 1 << (31 - port);
 	if ((rc = fsi_write(fsi_parent, 0x3404, value))) {

--- a/libpdbg/device.c
+++ b/libpdbg/device.c
@@ -501,7 +501,7 @@ static enum pdbg_target_status str_to_status(const char *status)
 	else if (!strcmp(status, "unknown"))
 		return PDBG_TARGET_UNKNOWN;
 	else
-		assert(0);
+		abort();
 }
 
 static int dt_expand_node(struct pdbg_target *node, void *fdt, int fdt_node)
@@ -600,10 +600,11 @@ uint64_t pdbg_target_address(struct pdbg_target *target, uint64_t *out_size)
 
 	u32 na = dt_n_address_cells(target);
 	u32 ns = dt_n_size_cells(target);
-	u32 n;
+#ifndef NDEBUG
+	u32 n = (na + ns) * sizeof(u32);
+#endif
 
 	p = dt_require_property(target, "reg", -1, &len);
-	n = (na + ns) * sizeof(u32);
 	assert(n <= len);
 	if (out_size)
 		*out_size = dt_get_number(p + na * sizeof(u32), ns);

--- a/src/mem.c
+++ b/src/mem.c
@@ -166,7 +166,7 @@ OPTCMD_DEFINE_CMD_WITH_FLAGS(getmemio, getmemio, (ADDRESS, DATA, BLOCK_SIZE),
 static int _putmem(const char *mem_prefix, uint64_t addr, uint8_t block_size, bool ci)
 {
 	uint8_t *buf;
-	size_t buflen;
+	size_t buflen = 0;
 	int rc, count = 0;
 	struct pdbg_target *target;
 


### PR DESCRIPTION
Fixe the following build failures with `-DNDEBUG`:

```
libpdbg/adu.c: In function 'blog2':
libpdbg/adu.c:112:1: error: control reaches end of non-void function [-Werror=return-type]
  112 | }
      | ^
  CC       libpdbg/libpdbg_la-chip.lo
  CC       libpdbg/libpdbg_la-cronus.lo
libpdbg/cfam.c: In function 'cfam_hmfsi_probe':
libpdbg/cfam.c:325:13: error: 'port' is used uninitialized in this function [-Werror=uninitialized]
  325 |  value |= 1 << (31 - port);
      |           ~~^~~~~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/9d90ede1ff7425cbb25b95aed3bf8d27ced865a4

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>