### PR TITLE
libpdbg: fix sbe_get_state return value

### DIFF
--- a/libpdbg/sbe_api.c
+++ b/libpdbg/sbe_api.c
@@ -297,7 +297,7 @@ int sbe_get_state(struct pdbg_target *pib, enum sbe_state *state)
 		if (rc)
 			return -1;
 
-		*state = msg.sbe_booted ? SBE_STATE_BOOTED : SBE_STATE_NOT_USABLE;
+		*state = msg.sbe_booted ? SBE_STATE_BOOTED : SBE_STATE_CHECK_CFAM;
 	} else {
 		*state = value;
 	}


### PR DESCRIPTION
Curently sbe_get_state api returns SBE_STATE_NOT_USABLE
incase SBE booted bit is not set. This api should return
the current value of SBE status register to align the BMC
sbe state management design direction. Like BMC sets SBE
state to SBE_STATE_CHECK_CFAM when chassis power is on and
based on the sbe message register status this get updated.
Here it is forcing to unusable state and it is causing
issue in SBE state management.

Tested: Successfully verified in BMC Driver verification test