### PR TITLE
Add timeout aftet SBE dump chip-ops

### DIFF
--- a/libsbefifo/cmd_dump.c
+++ b/libsbefifo/cmd_dump.c
@@ -75,10 +75,16 @@ int sbefifo_get_dump(struct sbefifo_context *sctx, uint8_t type, uint8_t clock, 
 	rc = sbefifo_get_dump_push(type, clock, fa_collect, &msg, &msg_len);
 	if (rc)
 		return rc;
+	rc = sbefifo_set_long_timeout(sctx);
+	if (rc) {
+		free(msg);
+		return rc;
+	}
 
 	/* dump size can be as large as 80MB */
 	out_len = 80 * 1024 * 1024;
 	rc = sbefifo_operation(sctx, msg, msg_len, &out, &out_len);
+	sbefifo_reset_timeout(sctx);
 	free(msg);
 	if (rc)
 		return rc;

--- a/libsbefifo/sbefifo_private.h
+++ b/libsbefifo/sbefifo_private.h
@@ -74,7 +74,7 @@
 #define   SBEFIFO_CMD_GET_TI_INFO          0x04 /* long running */
 
 #define SBEFIFO_CMD_CLASS_DUMP           0xAA00
-#define   SBEFIFO_CMD_GET_DUMP             0x01
+#define   SBEFIFO_CMD_GET_DUMP             0x01 /* long running */
 
 struct sbefifo_context {
 	int fd;


### PR DESCRIPTION
Setting timeout values after sbe dump chip-ops are missing adding the same.

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>
Change-Id: I6157697c1e7b363110f65d01c9b46b3936c14c2a