### PR TITLE
libpdbg: skip thread state updates during chipop failure

### DIFF
--- a/libpdbg/sbefifo.c
+++ b/libpdbg/sbefifo.c
@@ -322,7 +322,9 @@ static int sbefifo_pib_thread_start(struct pib *pib)
 
 	rc = sbefifo_pib_thread_op(pib, SBEFIFO_INSN_OP_START);
 
-	sbefifo_pib_update_threads(&pib->target);
+	if (!rc) {
+		sbefifo_pib_update_threads(&pib->target);
+	}
 
 	return rc;
 }
@@ -437,7 +439,9 @@ static int sbefifo_thread_start(struct thread *thread)
 
 	rc = sbefifo_thread_op(thread, SBEFIFO_INSN_OP_START);
 
-	thread->status = thread->state(thread);
+	if (!rc) {
+		thread->status = thread->state(thread);
+	}
 
 	return rc;
 }

--- a/libpdbg/sbefifo.c
+++ b/libpdbg/sbefifo.c
@@ -358,7 +358,9 @@ static int sbefifo_pib_thread_sreset(struct pib *pib)
 
 	rc = sbefifo_pib_thread_op(pib, SBEFIFO_INSN_OP_SRESET);
 
-	sbefifo_pib_update_threads(&pib->target);
+	if (!rc) {
+		sbefifo_pib_update_threads(&pib->target);
+	}
 
 	return rc;
 }
@@ -487,7 +489,9 @@ static int sbefifo_thread_sreset(struct thread *thread)
 
 	rc = sbefifo_thread_op(thread, SBEFIFO_INSN_OP_SRESET);
 
-	thread->status = thread->state(thread);
+	if (!rc) {
+		thread->status = thread->state(thread);
+	}
 
 	return rc;
 }

--- a/libpdbg/sbefifo.c
+++ b/libpdbg/sbefifo.c
@@ -333,7 +333,9 @@ static int sbefifo_pib_thread_stop(struct pib *pib)
 
 	rc = sbefifo_pib_thread_op(pib, SBEFIFO_INSN_OP_STOP);
 
-	sbefifo_pib_update_threads(&pib->target);
+	if (!rc) {
+		sbefifo_pib_update_threads(&pib->target);
+	}
 
 	return rc;
 }
@@ -446,7 +448,9 @@ static int sbefifo_thread_stop(struct thread *thread)
 
 	rc = sbefifo_thread_op(thread, SBEFIFO_INSN_OP_STOP);
 
-	thread->status = thread->state(thread);
+	if (!rc) {
+		thread->status = thread->state(thread);
+	}
 
 	return rc;
 }


### PR DESCRIPTION
Incase chip-op failure pdbg captures last chip-op FFDC information. 
Currently sbefifo back-end mode to get thread status, pdbg makes 
another chip-op. This will override the actual error.

This commits helps to return correct return code for thread start/stop/sreset
chip-ops by skipping thread status update call during failure.

