### PR TITLE
Adding helper functions for switching of devtree backend in the same process - Test case failure correction

### DIFF
--- a/libpdbg/device.c
+++ b/libpdbg/device.c
@@ -657,73 +657,6 @@ static void dt_link_virtual(struct pdbg_target *node, struct pdbg_target *vnode)
 	vnode->vnode = node;
 }
 
-/**
- * @brief A function to delete the children from the list
- * 
- * This function is called for a valid target/node to delete the children
- * from the list. Should be only called internally. Recursive in nature
- * 
- * @param target The target node for which the children will be reset
- * 
- * @see pdbg_reset_dt_root for more details
- */
-static void pdbg_reset_children(struct pdbg_target* target)
-{
-	struct pdbg_target* childTraget = NULL;
-	enum pdbg_target_status status;
-
-	/* Does this target actually exist? */
-	if (target)
-	{
-		status = pdbg_target_status(target);
-		if (status != PDBG_TARGET_ENABLED)
-			return;
-	}
-	pdbg_for_each_child_target(target, childTraget)
-	{			
-		if (childTraget)
-		{
-			pdbg_reset_children(childTraget);
-		}
-		if (!list_empty(&target->children) && target->class_link.next && target->class_link.prev)
-		{
-			list_del_from(&target->children, &target->class_link);
-		}
-	}
-	/**
-	 * As this is recursive in nature so only it would be exiting loop
-	 * when the last child node is taken into account and ready to be
-	 * free. Thus freeing it here. Putting it into the for loop would
-	 * cause it a double delete. 
-	 */
-	if (childTraget)
-	{
-		free(childTraget);
-		childTraget = NULL;
-	}
-}
-
-/**
- * @brief Reset the root node of a earlier set device tree
- * 
- * This function is called internally from targets init function to reset
- * the root node of the device tree which if was set earlier as well.
- * 
- * @see pdbg_targets_init for more details
- */
-static void pdbg_reset_dt_root()
-{
-	if (pdbg_dt_root)
-	{
-		pdbg_reset_children(pdbg_dt_root);
-		if (pdbg_dt_root)
-		{
-			free(pdbg_dt_root);
-			pdbg_dt_root = NULL;
-		}
-	}
-}
-
 static void pdbg_targets_init_virtual(struct pdbg_target *node, struct pdbg_target *root)
 {
 	struct pdbg_target *vnode, *child = NULL;
@@ -768,16 +701,66 @@ skip:
 	}
 }
 
+/**
+ * @brief A function to delete the children from the list
+ * 
+ * This function is called for a valid target/node to delete the children
+ * from the list. Should be only called internally. Recursive in nature
+ * 
+ * @param target The target node for which the children will be reset
+ * 
+ * @see pdbg_clear_dt_root for more details
+ */
+static void pdbg_target_free(struct pdbg_target* target)
+{
+	if (!target)
+		return;
+	
+	struct pdbg_target* childTarget = NULL;
+	pdbg_for_each_child_target(target, childTarget)
+	{			
+		pdbg_target_free(childTarget);
+		if (!list_empty(&target->children) && target->class_link.next && target->class_link.prev)
+		{
+			list_del_from(&target->children, &target->class_link);
+		}
+	}
+	/**
+	 * As this is recursive in nature so only it would be exiting loop
+	 * when the last child node is taken into account and ready to be
+	 * free. Thus freeing it here. Putting it into the for loop would
+	 * cause it a double delete. 
+	 */
+	if (childTarget)
+	{
+		free(childTarget);
+		childTarget = NULL;
+	}
+}
+
+void pdbg_release_dt_root()
+{
+	if (pdbg_dt_root)
+	{
+		pdbg_target_release(pdbg_dt_root);
+		pdbg_target_free(pdbg_dt_root);
+		if (pdbg_dt_root)
+		{
+			free(pdbg_dt_root);
+			pdbg_dt_root = NULL;
+		}
+	}
+}
+
 bool pdbg_targets_init(void *fdt)
 {
-	if (pdbg_dt_root) {
-		PR_INFO("pdbg_dt_root is already pointing to a dev tree, resetting it for the new one\n");
-		pdbg_reset_dt_root();
+	if (pdbg_dt_root) 
+	{
+		PR_WARNING("pdbg_targets_init() must be called only once\n");
+		return true;
 	}
 
 	struct pdbg_dtb* dtb = pdbg_default_dtb(fdt);
-
-	dtb = pdbg_default_dtb(fdt);
 
 	if (!dtb) {
 		pdbg_log(PDBG_ERROR, "Could not determine system\n");

--- a/libpdbg/dtb.c
+++ b/libpdbg/dtb.c
@@ -412,9 +412,15 @@ fail:
 
 bool pdbg_set_backend(enum pdbg_backend backend, const char *backend_option)
 {
-	if (pdbg_target_root() && (pdbg_backend == backend)) 
+	if (pdbg_target_root()) 
 	{
-		pdbg_log(PDBG_ERROR, "New Backend is same as the previous one. Not resetting it further\n");
+		pdbg_log(PDBG_ERROR, "pdbg_set_backend() must be called before pdbg_targets_init() or after calling pdbg_clear_dt_root() if a dev tree is already set\n");
+		return false;
+	}
+
+	if (pdbg_backend == backend)
+	{
+		pdbg_log(PDBG_ERROR, "New backend is same as the current backend. Not proceeding further\n");
 		return false;
 	}
 	

--- a/libpdbg/libpdbg.h
+++ b/libpdbg/libpdbg.h
@@ -1452,6 +1452,19 @@ void pdbg_log(int loglevel, const char *fmt, ...);
  */
 bool pdbg_context_short(void);
 
+/**
+ * @brief Clear/Release the earlier set device tree and it's root node
+ * 
+ * This function needs to be called if the backend of a dev tree
+ * getting switched in the same process. It clears/releases the 
+ * earlier set dev tree (if any) along with the root node.
+ * 
+ * Call this function before pdbg_set_backend() if there is a
+ * dev tree already is in place and we are switching the backend
+ * for really some good reasons
+ */
+void pdbg_release_dt_root();
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Adding helper functions for switching of devtree backend in the same process - Test case failure correction

With the commit made under #887f2569fb29065ca9becac046fab7be6d6a6efd it was breaking a test case in upstream which is corrected now with this commit

Signed-off-by: swarnendu.roy.chowdhury@ibm.com