### PR TITLE
Adding helper functions for switching of devtree backend in the same process

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,8 @@ GIT_SHA1 ?= `git --work-tree=$(top_srcdir) --git-dir=$(top_srcdir)/.git describe
 libpdbg_tests = libpdbg_target_test \
 		libpdbg_probe_test1 \
 		libpdbg_probe_test2 \
-		libpdbg_probe_test3
+		libpdbg_probe_test3 \
+		libpdbg_release_dt_root_test
 
 bin_PROGRAMS = pdbg
 check_PROGRAMS = $(libpdbg_tests) libpdbg_dtree_test \
@@ -248,6 +249,11 @@ libpdbg_target_test_SOURCES = src/tests/libpdbg_target_test.c
 libpdbg_target_test_CFLAGS = $(libpdbg_test_cflags)
 libpdbg_target_test_LDFLAGS = $(libpdbg_test_ldflags)
 libpdbg_target_test_LDADD = $(libpdbg_test_ldadd)
+
+libpdbg_release_dt_root_test_SOURCES = src/tests/libpdbg_release_dt_root_test.c
+libpdbg_release_dt_root_test_CFLAGS = $(libpdbg_test_cflags)
+libpdbg_release_dt_root_test_LDFLAGS = $(libpdbg_test_ldflags)
+libpdbg_release_dt_root_test_LDADD = $(libpdbg_test_ldadd)
 
 libpdbg_probe_test1_SOURCES = src/tests/libpdbg_probe_test.c
 libpdbg_probe_test1_CFLAGS = $(libpdbg_test_cflags) -DTEST_ID=1

--- a/libpdbg/device.c
+++ b/libpdbg/device.c
@@ -703,70 +703,71 @@ skip:
 
 /**
  * @brief It releases/deletes a target from its target_class list.
- * 		  Each pdbg_target object (except the virtuals one) has an
- *        associated target class linked via it's class_link. This
- * 		  function deletes/removes a target form the list of associated
- * 		  pdbg_target_class object. For internal use only.
+ *  Each pdbg_target object (except the virtuals one) has an
+ *  associated target class linked via it's class_link. This
+ *  function deletes/removes a target form the list of associated
+ *  pdbg_target_class object. For internal use only.
  * 
  * @param target The pdbg_target object which will be removed from it's associated
- * 				 pdbg_target_class list
+ *  pdbg_target_class list
  * 
  * @see pdbg_release_target for more details
  */
 static void pdbg_del_target_from_target_class_list(struct pdbg_target* target)
 {
-	if (!target)
-		return;
+    if (!target)
+        return;
 
-	struct pdbg_target_class* target_class = get_target_class(target);
-	if (target_class)
-		list_del_from(&target_class->targets, &target->class_link);
+    struct pdbg_target_class* target_class = get_target_class(target);
+    if (target_class)
+        list_del_from(&target_class->targets, &target->class_link);
 }
 
 /**
  * @brief A function to delete/release an existing pdbg_target object along
- * 		  with its children from the node list/dev tree. Recursive in nature.
- * 		  For internal use only.
+ * 	with its children from the node list/dev tree. Recursive in nature.
+ * 	For internal use only.
  * 
  * @param target The target node for which the children and then the node itself
- * 				 will be released/freed. Also remove the target from its parent's
- * 				 children's list if it is having one
+ * 	will be released/freed. Also remove the target from its parent's
+ * 	children's list if it is having one
  * 
  * @see pdbg_release_dt_root for more details
  */
 static void pdbg_release_target(struct pdbg_target* target)
 {
-	if (!target)
-		return;
+    if (!target)
+        return;
 
-	struct pdbg_target *childTarget, *next = NULL;
-	list_for_each_safe(&target->children, childTarget, next, list)
-		pdbg_release_target(childTarget);
+    struct pdbg_target *childTarget, *next = NULL;
+    list_for_each_safe(&target->children, childTarget, next, list)
+        pdbg_release_target(childTarget);
 		
-	if (target->class)
-			pdbg_del_target_from_target_class_list(target);
+    if (target->class)
+        pdbg_del_target_from_target_class_list(target);
 
-	struct pdbg_target* parentTarget = target->parent;
-	if (parentTarget)
-		list_del_from(&parentTarget->children, &target->list);
+    struct pdbg_target* parentTarget = target->parent;
+    if (parentTarget)
+        list_del_from(&parentTarget->children, &target->list);
 
-	if (target)
-		free(target);
-	target = NULL;
+    if (target)
+        free(target);
+    target = NULL;
 }
 
 void pdbg_release_dt_root()
 {
-	if (pdbg_dt_root)
-	{	
-		pdbg_release_target(pdbg_dt_root);
-		if (pdbg_dt_root)
-			pdbg_dt_root = NULL;
-		//Reset the phandle count to zero
-		last_phandle = 0;
-		//Clear the existing target classes
-		clear_target_classes();
-	}
+    if (pdbg_dt_root)
+    {	
+        pdbg_release_target(pdbg_dt_root);
+        if (pdbg_dt_root)
+            pdbg_dt_root = NULL;
+		
+        //Reset the phandle count to zero
+        last_phandle = 0;
+        //Clear the existing target classes
+        clear_target_classes();
+    }
 }
 
 bool pdbg_targets_init(void *fdt)

--- a/libpdbg/device.c
+++ b/libpdbg/device.c
@@ -701,6 +701,74 @@ skip:
 	}
 }
 
+/**
+ * @brief It releases/deletes a target from its target_class list.
+ * 		  Each pdbg_target object (except the virtuals one) has an
+ *        associated target class linked via it's class_link. This
+ * 		  function deletes/removes a target form the list of associated
+ * 		  pdbg_target_class object. For internal use only.
+ * 
+ * @param target The pdbg_target object which will be removed from it's associated
+ * 				 pdbg_target_class list
+ * 
+ * @see pdbg_release_target for more details
+ */
+static void pdbg_del_target_from_target_class_list(struct pdbg_target* target)
+{
+	if (!target)
+		return;
+
+	struct pdbg_target_class* target_class = get_target_class(target);
+	if (target_class)
+		list_del_from(&target_class->targets, &target->class_link);
+}
+
+/**
+ * @brief A function to delete/release an existing pdbg_target object along
+ * 		  with its children from the node list/dev tree. Recursive in nature.
+ * 		  For internal use only.
+ * 
+ * @param target The target node for which the children and then the node itself
+ * 				 will be released/freed. Also remove the target from its parent's
+ * 				 children's list if it is having one
+ * 
+ * @see pdbg_release_dt_root for more details
+ */
+static void pdbg_release_target(struct pdbg_target* target)
+{
+	if (!target)
+		return;
+
+	struct pdbg_target *childTarget, *next = NULL;
+	list_for_each_safe(&target->children, childTarget, next, list)
+		pdbg_release_target(childTarget);
+		
+	if (target->class)
+			pdbg_del_target_from_target_class_list(target);
+
+	struct pdbg_target* parentTarget = target->parent;
+	if (parentTarget)
+		list_del_from(&parentTarget->children, &target->list);
+
+	if (target)
+		free(target);
+	target = NULL;
+}
+
+void pdbg_release_dt_root()
+{
+	if (pdbg_dt_root)
+	{	
+		pdbg_release_target(pdbg_dt_root);
+		if (pdbg_dt_root)
+			pdbg_dt_root = NULL;
+		//Reset the phandle count to zero
+		last_phandle = 0;
+		//Clear the existing target classes
+		clear_target_classes();
+	}
+}
+
 bool pdbg_targets_init(void *fdt)
 {
 	struct pdbg_dtb *dtb;
@@ -733,6 +801,11 @@ bool pdbg_targets_init(void *fdt)
 	dt_expand(pdbg_dt_root, dtb->system.fdt);
 
 	pdbg_targets_init_virtual(pdbg_dt_root, pdbg_dt_root);
+
+	//Close any FDs which might be still opened
+	close(dtb->system.fd);
+	close(dtb->backend.fd);
+	
 	return true;
 }
 

--- a/libpdbg/dtb.c
+++ b/libpdbg/dtb.c
@@ -412,15 +412,17 @@ fail:
 
 bool pdbg_set_backend(enum pdbg_backend backend, const char *backend_option)
 {
-	if (pdbg_target_root()) {
-		pdbg_log(PDBG_ERROR, "pdbg_set_backend() must be called before pdbg_targets_init() or after calling pdbg_release_dt_root() if a dev tree is already set\n");
-		return false;
-	}
+    if (pdbg_target_root()) 
+    {
+        pdbg_log(PDBG_ERROR, "pdbg_set_backend() must be called before pdbg_targets_init()"
+            "or after calling pdbg_release_dt_root() if a dev tree is already set\n");	
+        return false;
+    }
 
-	pdbg_backend = backend;
-	pdbg_backend_option = backend_option;
+    pdbg_backend = backend;
+    pdbg_backend_option = backend_option;
 
-	return true;
+    return true;
 }
 
 enum pdbg_backend pdbg_get_backend(void)

--- a/libpdbg/dtb.c
+++ b/libpdbg/dtb.c
@@ -413,7 +413,7 @@ fail:
 bool pdbg_set_backend(enum pdbg_backend backend, const char *backend_option)
 {
 	if (pdbg_target_root()) {
-		pdbg_log(PDBG_ERROR, "pdbg_set_backend() must be called before pdbg_targets_init()\n");
+		pdbg_log(PDBG_ERROR, "pdbg_set_backend() must be called before pdbg_targets_init() or after calling pdbg_release_dt_root() if a dev tree is already set\n");
 		return false;
 	}
 

--- a/libpdbg/libpdbg.h
+++ b/libpdbg/libpdbg.h
@@ -1452,6 +1452,18 @@ void pdbg_log(int loglevel, const char *fmt, ...);
  */
 bool pdbg_context_short(void);
 
+/**
+ * @brief Clears/Releases the existing device tree and it's root node
+ * 
+ * This function needs to be called if for some very good reason we are
+ * switching the backend in the running process. It clears/releases the 
+ * existing dev tree (if any) children by children along with the root node.
+ * 
+ * Call this function before ##pdbg_set_backend() if there is a
+ * dev tree already is in place and we are switching the backend
+ */
+void pdbg_release_dt_root();
+
 #ifdef __cplusplus
 }
 #endif

--- a/libpdbg/target.c
+++ b/libpdbg/target.c
@@ -641,13 +641,13 @@ struct pdbg_target *target_to_virtual(struct pdbg_target *target, bool strict)
 
 void clear_target_classes()
 {
-	struct pdbg_target_class *child = NULL;
-	struct pdbg_target_class *next = NULL;
-	list_for_each_safe(&target_classes, child, next, class_head_link)
-	{
-		list_del_from(&target_classes, &child->class_head_link);
-		if (child)
-			free(child);
-		child = NULL;
-	}
+    struct pdbg_target_class *child = NULL;
+    struct pdbg_target_class *next = NULL;
+    list_for_each_safe(&target_classes, child, next, class_head_link)
+    {
+        list_del_from(&target_classes, &child->class_head_link);
+        if (child)
+            free(child);
+        child = NULL;
+    }
 }

--- a/libpdbg/target.c
+++ b/libpdbg/target.c
@@ -638,3 +638,16 @@ struct pdbg_target *target_to_virtual(struct pdbg_target *target, bool strict)
 
 	return target;
 }
+
+void clear_target_classes()
+{
+	struct pdbg_target_class *child = NULL;
+	struct pdbg_target_class *next = NULL;
+	list_for_each_safe(&target_classes, child, next, class_head_link)
+	{
+		list_del_from(&target_classes, &child->class_head_link);
+		if (child)
+			free(child);
+		child = NULL;
+	}
+}

--- a/libpdbg/target.h
+++ b/libpdbg/target.h
@@ -99,10 +99,10 @@ bool pdbg_context_is_short(void);
 
 /**
  * @brief Clears the list of target classes
- * 		  It clears the list of target classes
- * 		  from the global static list target_classes
- * 		  once the device tree is cleared and associated
- * 		  all pdbg_target objects are destroyed
+ * It clears the list of target classes
+ * from the global static list target_classes
+ * once the device tree is cleared and associated
+ * all pdbg_target objects are destroyed
  * 
  * @see   pdbg_release_dt_root() for more details
  */

--- a/libpdbg/target.h
+++ b/libpdbg/target.h
@@ -97,4 +97,15 @@ struct pdbg_target *target_to_virtual(struct pdbg_target *target, bool strict);
 
 bool pdbg_context_is_short(void);
 
+/**
+ * @brief Clears the list of target classes
+ * 		  It clears the list of target classes
+ * 		  from the global static list target_classes
+ * 		  once the device tree is cleared and associated
+ * 		  all pdbg_target objects are destroyed
+ * 
+ * @see   pdbg_release_dt_root() for more details
+ */
+void clear_target_classes();
+
 #endif

--- a/src/tests/libpdbg_release_dt_root_test.c
+++ b/src/tests/libpdbg_release_dt_root_test.c
@@ -1,0 +1,421 @@
+/* Copyright 2023 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+#include <assert.h>
+
+#include <libpdbg.h>
+
+static int count_target(struct pdbg_target *parent, const char *classname)
+{
+    struct pdbg_target *target = NULL;
+    int cnt = 0;
+
+    pdbg_for_each_target(classname, parent, target)
+        ++cnt;
+
+    return cnt;
+}
+
+static int count_class_target(const char *classname)
+{
+    struct pdbg_target *target = NULL;
+    int cnt = 0;
+
+    pdbg_for_each_class_target(classname, target)
+        ++cnt;
+
+    return cnt;
+}
+
+static int count_child_target(struct pdbg_target *parent)
+{
+    struct pdbg_target *child = NULL;
+    int cnt = 0;
+
+    pdbg_for_each_child_target(parent, child)
+        ++cnt;
+
+    return cnt;
+}
+
+static void testClassCountTarget()
+{
+    int count = count_class_target("fsi");
+    assert(count == 8);
+
+    count = count_class_target("pib");
+    assert(count == 8);
+
+    count = count_class_target("core");
+    assert(count == 32);
+
+    count = count_class_target("thread");
+    assert(count == 64);
+}
+
+static void testClassCountTargetWhenDevTreeIsReleased()
+{
+    int count = count_class_target("fsi");
+    assert(count == 0);
+
+    count = count_class_target("pib");
+    assert(count == 0);
+
+    count = count_class_target("core");
+    assert(count == 0);
+
+    count = count_class_target("thread");
+    assert(count == 0);
+}
+
+static void testSetTwo(struct pdbg_target *root)
+{
+    struct pdbg_target *parent, *target = NULL;
+    pdbg_for_each_child_target(root, parent) 
+    {
+        const char *name = pdbg_target_dn_name(parent);
+        assert(strncmp(name, "proc", 4) == 0);
+
+        pdbg_for_each_target("pib", parent, target)
+        {
+            name = pdbg_target_class_name(target);
+            assert(!strcmp(name, "pib"));
+        }
+
+        pdbg_for_each_target("fsi", parent, target)
+        {
+            name = pdbg_target_class_name(target);
+            assert(!strcmp(name, "fsi"));
+        }
+    }
+}
+
+static void testSetOne(struct pdbg_target *root)
+{
+    assert(root);
+    testClassCountTarget();
+    testSetTwo(root);
+}
+
+static void testFsiTarget()
+{
+    struct pdbg_target *parent, *target = NULL;
+    pdbg_for_each_class_target("fsi", target) 
+    {
+        parent = pdbg_target_parent(NULL, target);
+        assert(parent);
+
+        const char *name = pdbg_target_dn_name(parent);
+        assert(strncmp(name, "proc", 4) == 0);
+
+        parent = pdbg_target_parent("fsi", target);
+        assert(parent == NULL);
+
+        parent = pdbg_target_parent("pib", target);
+        assert(parent == NULL);
+
+        parent = pdbg_target_parent("core", target);
+        assert(parent == NULL);
+
+        parent = pdbg_target_parent("thread", target);
+        assert(parent == NULL);
+
+        int count = count_child_target(target);
+        assert(count == 0);
+
+        count = count_target(target, "fsi");
+        assert(count == 1);
+
+        count = count_target(target, "pib");
+        assert(count == 0);
+
+        count = count_target(target, "core");
+        assert(count == 0);
+
+        count = count_target(target, "thread");
+        assert(count == 0);
+
+        name = pdbg_target_name(target);
+        assert(!strcmp(name, "Fake FSI"));
+
+        name = pdbg_target_class_name(target);
+        assert(!strcmp(name, "fsi"));
+
+        name = pdbg_target_dn_name(target);
+        assert(!strncmp(name, "fsi", 3));
+    }
+}
+
+static void testFsiTargetWhenDevTreeIsReleased()
+{
+    struct pdbg_target *parent, *target = NULL;
+    pdbg_for_each_class_target("fsi", target)
+    {
+        parent = pdbg_target_parent(NULL, target);
+        assert(!parent);
+    }
+}
+
+static void testPibTarget()
+{
+    struct pdbg_target *parent, *target = NULL;
+    pdbg_for_each_class_target("pib", target) 
+    {
+        parent = pdbg_target_parent(NULL, target);
+        assert(parent);
+
+        const char *name = pdbg_target_dn_name(parent);
+        assert(strncmp(name, "proc", 4) == 0);
+
+        parent = pdbg_target_parent("fsi", target);
+        assert(parent == NULL);
+
+        parent = pdbg_target_parent("pib", target);
+        assert(parent == NULL);
+
+        parent = pdbg_target_parent("core", target);
+        assert(parent == NULL);
+
+        parent = pdbg_target_parent("thread", target);
+        assert(parent == NULL);
+
+        int count = count_child_target(target);
+        assert(count == 4);
+
+        count = count_target(target, "fsi");
+        assert(count == 0);
+
+        count = count_target(target, "pib");
+        assert(count == 1);
+
+        count = count_target(target, "core");
+        assert(count == 4);
+
+        count = count_target(target, "thread");
+        assert(count == 8);
+
+        name = pdbg_target_name(target);
+        assert(!strcmp(name, "Fake PIB"));
+
+        name = pdbg_target_class_name(target);
+        assert(!strcmp(name, "pib"));
+
+        name = pdbg_target_dn_name(target);
+        assert(!strncmp(name, "pib", 3));
+    }
+}
+
+static void testPibTargetWhenDevTreeIsReleased()
+{
+    struct pdbg_target *parent, *target = NULL;
+    pdbg_for_each_class_target("pib", target)
+    {
+        parent = pdbg_target_parent(NULL, target);
+        assert(!parent);
+    }
+}
+
+static void testCoreTarget()
+{
+    struct pdbg_target *parent, *target, *parent2 = NULL;
+    pdbg_for_each_class_target("core", target) 
+    {
+        uint64_t addr, size;
+        uint32_t index;
+
+        parent = pdbg_target_parent("fsi", target);
+        assert(parent == NULL);
+
+        parent = pdbg_target_parent("pib", target);
+        assert(parent);
+
+        parent2 = pdbg_target_require_parent("pib", target);
+        assert(parent == parent2);
+
+        parent = pdbg_target_parent("core", target);
+        assert(parent == NULL);
+
+        parent = pdbg_target_parent("thread", target);
+        assert(parent == NULL);
+
+        int count = count_child_target(target);
+        assert(count == 2);
+
+        count = count_target(target, "fsi");
+        assert(count == 0);
+
+        count = count_target(target, "pib");
+        assert(count == 0);
+
+        count = count_target(target, "core");
+        assert(count == 1);
+
+        count = count_target(target, "thread");
+        assert(count == 2);
+
+        const char *name = pdbg_target_name(target);
+        assert(!strcmp(name, "Fake Core"));
+
+        name = pdbg_target_class_name(target);
+        assert(!strcmp(name, "core"));
+
+        name = pdbg_target_dn_name(target);
+        assert(!strncmp(name, "core", 4));
+
+        index = pdbg_target_index(target);
+        addr = pdbg_target_address(target, &size);
+        assert(size == 0);
+        assert(addr == 0x10000 + (index + 1)*0x10);
+    }
+}
+
+static void testCoreTargetWhenDevTreeIsReleased()
+{
+    struct pdbg_target *parent, *target, *parent2 = NULL;
+    pdbg_for_each_class_target("core", target)
+    {
+        parent = pdbg_target_parent("fsi", target);
+        assert(parent == NULL);
+
+        parent = pdbg_target_parent("pib", target);
+        assert(parent == NULL);
+    }
+}
+
+static void testThreadTarget()
+{
+    struct pdbg_target *parent, *target, *parent2 = NULL;
+    pdbg_for_each_class_target("thread", target) 
+    {
+        parent = pdbg_target_parent("fsi", target);
+        assert(parent == NULL);
+
+        parent = pdbg_target_parent("pib", target);
+        assert(parent);
+
+        parent2 = pdbg_target_require_parent("pib", target);
+        assert(parent == parent2);
+
+        parent = pdbg_target_parent("core", target);
+        assert(parent);
+
+        parent2 = pdbg_target_require_parent("core", target);
+        assert(parent == parent2);
+
+        parent = pdbg_target_parent("thread", target);
+        assert(parent == NULL);
+
+        int count = count_child_target(target);
+        assert(count == 0);
+
+        count = count_target(target, "fsi");
+        assert(count == 0);
+
+        count = count_target(target, "pib");
+        assert(count == 0);
+
+        count = count_target(target, "core");
+        assert(count == 0);
+
+        count = count_target(target, "thread");
+        assert(count == 1);
+
+        const char *name = pdbg_target_name(target);
+        assert(!strcmp(name, "Fake Thread"));
+
+        name = pdbg_target_class_name(target);
+        assert(!strcmp(name, "thread"));
+
+        name = pdbg_target_dn_name(target);
+        assert(!strncmp(name, "thread", 6));
+    }
+}
+
+static void testThreadTargetWhenDevTreeIsReleased()
+{
+    struct pdbg_target *parent, *target = NULL;
+    pdbg_for_each_class_target("thread", target)
+    {
+        parent = pdbg_target_parent("fsi", target);
+        assert(parent == NULL);
+
+        parent = pdbg_target_parent("pib", target);
+        assert(parent == NULL);
+    }
+}
+
+static void testVariousTargets()
+{
+    testFsiTarget();
+    testPibTarget();
+    testCoreTarget();
+    testThreadTarget();
+}
+
+static void testVariousTargetsWhenDevTreeIsReleased()
+{
+    testFsiTargetWhenDevTreeIsReleased();
+    testPibTargetWhenDevTreeIsReleased();
+    testCoreTargetWhenDevTreeIsReleased();
+    testThreadTargetWhenDevTreeIsReleased();
+}
+
+int main(void)
+{
+    /**
+     * First set the backend to FAKE and inits the targets
+     * then test for various target counts for each class
+     * and other stuffs
+    */
+    assert(pdbg_set_backend(PDBG_BACKEND_FAKE, NULL));
+    assert(pdbg_targets_init(NULL));
+    {
+        struct pdbg_target* root = pdbg_target_root();
+        testSetOne(root);
+        testVariousTargets();
+
+        /**
+         * Now releases the device tree and check for root
+         * invalidation and subsequent tests
+        */
+        {
+            pdbg_release_dt_root();
+            testClassCountTargetWhenDevTreeIsReleased();
+            testVariousTargetsWhenDevTreeIsReleased();
+            root = pdbg_target_root();
+            assert(root == NULL);
+        }
+    }
+    /**
+     * Now again set the backend to FAKE one and inits the targets.
+     * Testing against the same set of conditions now should work as
+     * it did for earlier. Logic is if there in any leftover targets
+     *  or target classes after releasing of device tree then the counts 
+     * will be mismatched for the conditions set for a fresh device tree
+    */
+    assert(pdbg_set_backend(PDBG_BACKEND_FAKE, NULL));
+    assert(pdbg_targets_init(NULL));
+    {
+        struct pdbg_target* root = pdbg_target_root();
+        testSetOne(root);
+        testVariousTargets();
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Context: It is now required that the devtree backend in BMC systems should be able to switch in the same process on runtime e.g.; from KERNEL to SBEFIFO or vice-versa. This is to support running extract SBE RC hardware procedure. This commit introduces the necessary changes in order to achieve that.

Solution: It basically introduces few functions which will clear the pdbg_dt_root and its associated children subsequently if the pdbg_targets_init function is called more than once now (earlier it was not allowed to call pdbg_targets_init function twice in the same process)

Test-1: The switching of the backend in the same process was tested through a standalone application which runs in a loop for multiple times and each time it sets the intial backend to SBEFIFO first and then switched it to KERNEL. Trace log is attached along with the PR

Test-2: While booting BMC up injected a clock error during IPL in between istep0 to istep2 and call the SBR RC extract procedure to get the error code after switching the backend from SBEFIFO to KERNEL. Once the extraction is done switched back to SBEFIFO for further processing. Journal log is attached with the PR.

Signed-off-by: swarnendu.roy.chowdhury@ibm.com

[TraceLog_KARNEL_First.txt](https://github.com/open-power/pdbg/files/12803371/TraceLog_KARNEL_First.txt)
[TraceLog_SBEFIFO_First.txt](https://github.com/open-power/pdbg/files/12803372/TraceLog_SBEFIFO_First.txt)
<img width="327" alt="Test_run_screenshot_1" src="https://github.com/open-power/pdbg/assets/112170550/39f684ea-f8d4-44da-8f13-270ad748a6ba">
<img width="601" alt="Test_run_screenshot_2" src="https://github.com/open-power/pdbg/assets/112170550/2765d58d-8e9a-4762-96a7-a0becc0d10d2">
