### PR TITLE
OCMB target type renamed to "OCMB"

### DIFF
--- a/libpdbg/ocmb.c
+++ b/libpdbg/ocmb.c
@@ -69,7 +69,7 @@ static int sbefifo_ocmb_putscom(struct ocmb *ocmb, uint64_t addr, uint64_t value
 
 static struct ocmb sbefifo_ocmb = {
 	.target = {
-		.name = "SBE FIFO Chip-op based OCMB",
+		.name = "OCMB",
 		.compatible = "ibm,power-ocmb",
 		.class = "ocmb",
 	},


### PR DESCRIPTION
Tested
before
  {
    "MANUAL_ISOLATION": {
      "CURRENT_STATE": "DECONFIGURED",
      "LOCATION_CODE": "Ufcs-P0-C17",
      "PHYS_PATH": "physical:sys-0/node-0/ocmb_chip-9",
      "REASON_DESCRIPTION": "MANUAL",
      "TYPE": "SBE FIFO Chip-op based OCMB"
    }
after
  {
      "MANUAL_ISOLATION": {
      "CURRENT_STATE": "DECONFIGURED",
      "LOCATION_CODE": "Ufcs-P0-C17",
      "PHYS_PATH": "physical:sys-0/node-0/ocmb_chip-9",
      "REASON_DESCRIPTION": "MANUAL",
      "TYPE": "OCMB"
   }


Change-Id: I4b7eb25a76968a435b78db858923b8a068ca225b