### PR TITLE
Revert class names of pib and fsi targets for odyssey chips

### DIFF
--- a/bmc-kernel.dts.m4
+++ b/bmc-kernel.dts.m4
@@ -24,7 +24,7 @@ define(`PIB_ODY',
 		#address-cells = <0x2>;
 		#size-cells = <0x1>;
 		reg = <0x0 0x$1 0x8000>; /*dummy to fix dts warning*/
-		compatible = "ibm,kernel-pib-ody";
+		compatible = "ibm,kernel-pib";
 		index = <0x$1>;
 		proc = <0x$2>;
 		port = <$4>;
@@ -146,7 +146,7 @@ define(`HMFSI_ODY',
 	hmfsi-ody@$3$4 {
 		#address-cells = <0x2>;
 		#size-cells = <0x1>;
-		compatible = "ibm,kernel-fsi-ody";
+		compatible = "ibm,kernel-fsi";
 		device-path = "/i2cr$3$4/slave@00:00/raw";
 		reg = <0x0 0x$1 0x8000>; /*dummy to fix dts warning*/
 		index = <0x$1>;

--- a/libpdbg/kernel.c
+++ b/libpdbg/kernel.c
@@ -214,20 +214,6 @@ static struct fsi kernel_fsi = {
 };
 DECLARE_HW_UNIT(kernel_fsi);
 
-static struct fsi kernel_fsi_ody = {
-    .target = {
-        .name = "Kernel based FSI master for odyssey",
-        .compatible = "ibm,kernel-fsi-ody",
-        .class = "fsi-ody",
-        .probe = kernel_fsi_probe,
-        .release = kernel_fsi_release,
-    },
-    .read = kernel_fsi_getcfam,
-    .write = kernel_fsi_putcfam,
-};
-DECLARE_HW_UNIT(kernel_fsi_ody);
-
-
 static int kernel_pib_getscom(struct pib *pib, uint64_t addr, uint64_t *value)
 {
 	int rc;
@@ -284,24 +270,10 @@ struct pib kernel_pib = {
 };
 DECLARE_HW_UNIT(kernel_pib);
 
-struct pib kernel_pib_ody = {
-    .target = {
-        .name = "Kernel based FSI SCOM for odyssey",
-        .compatible = "ibm,kernel-pib-ody",
-        .class = "pib-ody",
-        .probe = kernel_pib_probe,
-    },
-    .read = kernel_pib_getscom,
-    .write = kernel_pib_putscom,
-};
-DECLARE_HW_UNIT(kernel_pib_ody);
-
 
 __attribute__((constructor))
 static void register_kernel(void)
 {
 	pdbg_hwunit_register(PDBG_DEFAULT_BACKEND, &kernel_fsi_hw_unit);
-	pdbg_hwunit_register(PDBG_DEFAULT_BACKEND, &kernel_fsi_ody_hw_unit);
 	pdbg_hwunit_register(PDBG_DEFAULT_BACKEND, &kernel_pib_hw_unit);
-	pdbg_hwunit_register(PDBG_DEFAULT_BACKEND, &kernel_pib_ody_hw_unit);
 }

--- a/libpdbg/target.c
+++ b/libpdbg/target.c
@@ -865,12 +865,12 @@ struct chipop_ody *ody_ocmb_to_chipop(struct pdbg_target *target)
 
 struct pdbg_target* get_ody_pib_target(struct pdbg_target *target)
 {
-	return get_backend_target("pib-ody", target);
+	return get_backend_target("pib", target);
 }
 
 struct pdbg_target* get_ody_fsi_target(struct pdbg_target *target)
 {
-	return get_backend_target("fsi-ody", target);
+	return get_backend_target("fsi", target);
 }
 
 struct pdbg_target* get_ody_chipop_target(struct pdbg_target *target)


### PR DESCRIPTION
At present class name of odyssey pib and fsi targets are set by appending "ody" to "pib" and "fsi" names to differntiate from ddr4 pib, fsi targets to ddr5 pib and fsi targets.

It was done to limit the search for the pib/fsi target of the odyssey chip when looping through all the pib and fsi target for the matching proc and ocmb target. Not much advantage though but done for clarity.

The change in class names for ody pib and fsi targets are failing in some of the sbe methods like sbe_set_state which are expecting old pib and fsi class names.


Change-Id: Ibe589b73e8561c33d2166af812cd4f25aa59078e