### PR TITLE
cater for get and set sbe odyssey state

### DIFF
--- a/libpdbg/libpdbg_sbe.h
+++ b/libpdbg/libpdbg_sbe.h
@@ -105,9 +105,9 @@ int sbe_dump(struct pdbg_target *target, uint8_t type, uint8_t clock, uint8_t fa
 int sbe_get_state(struct pdbg_target *target, enum sbe_state *state);
 
 /**
- * @brief Get Odyssey sbe state
+ * @brief Get odyssey sbe state
  *
- * Get the current state of Odyssey SBE
+ * Get the current state of odyssey SBE
  *
  * @param[in] target fsi target to operate on
  * @param[out] state sbe state
@@ -127,6 +127,18 @@ int sbe_ody_get_state(struct pdbg_target *fsi, enum sbe_state *state);
  * @return 0 on success, -1 on failure
  */
 int sbe_set_state(struct pdbg_target *target, enum sbe_state state);
+
+/**
+ * @brief Set odyssey sbe state
+ *
+ * Set the current state of odyssey SBE
+ *
+ * @param[in] fsi fsi target to operate on
+ * @param[in] state odyssey sbe state
+ *
+ * @return 0 on success, -1 on failure
+ */
+int sbe_ody_set_state(struct pdbg_target *fsi, enum sbe_state state);
 
 /**
  * @brief Check if IPL boot is complete

--- a/libpdbg/libpdbg_sbe.h
+++ b/libpdbg/libpdbg_sbe.h
@@ -105,6 +105,18 @@ int sbe_dump(struct pdbg_target *target, uint8_t type, uint8_t clock, uint8_t fa
 int sbe_get_state(struct pdbg_target *target, enum sbe_state *state);
 
 /**
+ * @brief Get Odyssey sbe state
+ *
+ * Get the current state of Odyssey SBE
+ *
+ * @param[in] target fsi target to operate on
+ * @param[out] state sbe state
+ *
+ * @return 0 on success, -1 on failure
+ */
+int sbe_ody_get_state(struct pdbg_target *fsi, enum sbe_state *state);
+
+/**
  * @brief Set sbe state
  *
  * Set the current state of SBE

--- a/libpdbg/sbe_api.c
+++ b/libpdbg/sbe_api.c
@@ -320,7 +320,7 @@ static int sbe_ody_read_msg_register(struct pdbg_target *fsi, uint32_t *value)
 
 	rc = fsi_ody_read(fsi, SBE_MSG_REG, value);
 	if (rc) {
-		PR_NOTICE("Failed to read sbe mailbox register\n");
+		PR_NOTICE("Failed to read ody sbe mailbox register\n");
 		return rc;
 	}
 
@@ -339,7 +339,7 @@ static int sbe_ody_read_state_register(struct pdbg_target *fsi, uint32_t *value)
 
 	rc = fsi_ody_read(fsi, SBE_STATE_REG, value);
 	if (rc) {
-		PR_NOTICE("Failed to read sbe state register\n");
+		PR_NOTICE("Failed to read ody sbe state register\n");
 		return rc;
 	}
 	return 0;
@@ -359,6 +359,25 @@ static int sbe_write_state_register(struct pdbg_target *pib, uint32_t value)
 	rc = fsi_write(fsi, SBE_STATE_REG, value);
 	if (rc) {
 		PR_NOTICE("Failed to write sbe state register\n");
+		return rc;
+	}
+
+	return 0;
+}
+
+static int sbe_ody_write_state_register(struct pdbg_target *fsi, uint32_t value)
+{
+	int rc;
+
+	assert(fsi);
+	assert(pdbg_target_is_class(fsi, "fsi-ody"));
+
+	if (pdbg_target_status(fsi) != PDBG_TARGET_ENABLED)
+		return -1;
+
+	rc = fsi_ody_write(fsi, SBE_STATE_REG, value);
+	if (rc) {
+		PR_NOTICE("Failed to write ody sbe state register\n");
 		return rc;
 	}
 
@@ -415,6 +434,18 @@ int sbe_set_state(struct pdbg_target *pib, enum sbe_state state)
 	int rc;
 
 	rc = sbe_write_state_register(pib, value);
+	if (rc)
+		return -1;
+
+	return 0;
+}
+
+int sbe_ody_set_state(struct pdbg_target *fsi, enum sbe_state state)
+{
+	uint32_t value = state;
+	int rc;
+
+	rc = sbe_ody_write_state_register(fsi, value);
 	if (rc)
 		return -1;
 

--- a/libpdbg/target.c
+++ b/libpdbg/target.c
@@ -644,6 +644,7 @@ enum pdbg_target_status pdbg_target_probe_ody_ocmb(struct pdbg_target *target)
 			return PDBG_TARGET_NONEXISTENT;
 		}
 
+		fsitarget->status = PDBG_TARGET_ENABLED;
 		target->status = PDBG_TARGET_ENABLED;
 		pibtarget->status = PDBG_TARGET_ENABLED;
 	}


### PR DESCRIPTION
1) Provide methods to read odyssey sbe state
2) User odyssey fsi target to read the sbe state

Tested:
PDBG:fsi_ody_read[382]: rc = 0, addr = 0x02986, data = 0x00000000, target = /hmfsi-ody@310 sbe state value is 0


Change-Id: I59aa51a90bc235b989e65c937a7ed9b7d2e40a57