### PR TITLE
allow other applications to use ody ocmb check method

### DIFF
--- a/libpdbg/libpdbg.h
+++ b/libpdbg/libpdbg.h
@@ -856,6 +856,14 @@ struct pdbg_target* get_ody_fsi_target(struct pdbg_target* target);
 struct pdbg_target* get_ody_chipop_target(struct pdbg_target* target);
 
 /**
+ * @brief Return true if given target is odyssey chip
+ * @param[in] target - pdbg target
+ *
+ * @return true if target is of odyssey ocmb chip
+ */
+bool is_ody_ocmb_chip(struct pdbg_target *target);
+
+/**
  * @brief Read data from i2c device
  *
  * The target can be:

--- a/libpdbg/target.h
+++ b/libpdbg/target.h
@@ -109,14 +109,6 @@ bool pdbg_context_is_short(void);
 void clear_target_classes();
 
 /**
- * @brief Return true if given target is odyssey chip
- * @param[in] target - pdbg target
- *
- * @return true if target is of odyssey ocmb chip
- */
-bool is_ody_ocmb_chip(struct pdbg_target *target);
-
-/**
  * @brief Return true if given target is child of odyssey chip
  * @param[in] target - pdbg target
  *


### PR DESCRIPTION
moving is_ody_obmc_chip method to libpdbg.h so that other applications can use rather than writing there own functions.


Change-Id: I72b50c1f16dd6b1030137f7086d621338592151d