### PR TITLE
libpdbg: Add On Chip Controller (OCC) hardware unit

### DIFF
--- a/libpdbg/hwunit.h
+++ b/libpdbg/hwunit.h
@@ -390,4 +390,9 @@ struct pmic {
 };
 #define target_to_pmic(x) container_of(x, struct pmic, target)
 
+struct occ {
+        struct pdbg_target target;
+};
+#define target_to_occ(x) container_of(x, struct occ, target)
+
 #endif /* __HWUNIT_H */

--- a/libpdbg/p10_fapi_targets.c
+++ b/libpdbg/p10_fapi_targets.c
@@ -652,6 +652,16 @@ struct pmic p10_pmic= {
 };
 DECLARE_HW_UNIT(p10_pmic);
 
+struct occ p10_occ= {
+	.target = {
+		.name = "POWER10 On Chip Controller",
+		.compatible = "ibm,power10-occ",
+		.class = "occ",
+		.translate = no_translate,
+	},
+};
+DECLARE_HW_UNIT(p10_occ);
+
 __attribute__((constructor))
 static void register_p10_fapi_targets(void)
 {
@@ -680,4 +690,5 @@ static void register_p10_fapi_targets(void)
 	pdbg_hwunit_register(PDBG_DEFAULT_BACKEND, &p10_adc_hw_unit);
 	pdbg_hwunit_register(PDBG_DEFAULT_BACKEND, &p10_gpio_expander_hw_unit);
 	pdbg_hwunit_register(PDBG_DEFAULT_BACKEND, &p10_pmic_hw_unit);
+	pdbg_hwunit_register(PDBG_DEFAULT_BACKEND, &p10_occ_hw_unit);
 }


### PR DESCRIPTION
OCC is not in hardware unit list as it is not guardable. But, when a proc is guarded OCC is deconfigured by association. Currently we are not seeing OCC in Nag Dump because of unavailable properties like "name" and "class". So, Adding OCC to hardware unit list.

Test Results:

Before:

OCC was not showing up in Nag Dump.

After:

```
root@p10bmc:/tmp/test# faultlog -f
<6> faultlog app to collect deconfig/guard records details <6> Latest chassis poweron time read is :03/20/2024 15:33:49 [
  {
    "SYSTEM": {
      "SYSTEM_TYPE": "9105-42A"
    }
  },
  {
    "POLICY": {
      "FCO_VALUE": 0,
      "MASTER": true,
      "PREDICTIVE": true
    }
  },
  {
    "MANUAL_ISOLATION": {
      "CURRENT_STATE": "DECONFIGURED",
      "LOCATION_CODE": "Ufcs-P0-C15",
      "PHYS_PATH": "physical:sys-0/node-0/proc-1",
      "REASON_DESCRIPTION": "MANUAL",
      "TYPE": "Processor Module"
    }
  },
  {
    "DECONFIGURED": {
      "CURRENT_STATE": "DECONFIGURED",
      "LOCATION_CODE": "Ufcs-P0-C15",
      "PHYS_PATH": "physical:sys-0/node-0/proc-1/nx-0",
      "PLID": 0,
      "REASON_DESCRIPTION": "MANUAL",
      "TYPE": "POWER10 Nest Accelerator unit"
    }
  },
  {
    "DECONFIGURED": {
      "CURRENT_STATE": "DECONFIGURED",
      "LOCATION_CODE": "Ufcs-P0-C15",
      "PHYS_PATH": "physical:sys-0/node-0/proc-1/occ-0",  --> OCC is added now
      "PLID": 0,
      "REASON_DESCRIPTION": "MANUAL",
      "TYPE": "POWER10 On Chip Controller"
    }
  },
```

Change-Id: I5930cc4135b1573e56e9ea6a1967a69632e59e20