### PR TITLE
POZ: To cater for additional requirements to parse SBE FFDC data

### DIFF
--- a/libpdbg/sbefifo.c
+++ b/libpdbg/sbefifo.c
@@ -178,6 +178,11 @@ static uint32_t sbefifo_op_ffdc_get(struct chipop *chipop, const uint8_t **ffdc,
 	if (status)
 		return status;
 
+	//if there is ffdc data for success case then parse it
+	if (*ffdc_len > 0) {
+		return status;
+	}
+
 	/* Check if async FFDC is set */
 	rc = fsi_read(fsi, SBE_MSG_REG, &value);
 	if (rc) {
@@ -209,6 +214,11 @@ static uint32_t sbefifo_op_ody_ffdc_get(struct chipop_ody *chipop, struct pdbg_t
 	status = sbefifo_ffdc_get(sctx, ffdc, ffdc_len);
 	if (status)
 		return status;
+
+	//if there is ffdc data for success case then parse it
+	if (*ffdc_len > 0) {
+		return status;
+	}
 
 	/* Check if async FFDC is set */
 	rc = fsi_ody_read(fsi, SBE_MSG_REG, &value);

--- a/libsbefifo/ffdc.c
+++ b/libsbefifo/ffdc.c
@@ -48,7 +48,9 @@ void sbefifo_ffdc_set(struct sbefifo_context *sctx, uint32_t status, uint8_t *ff
 
 uint32_t sbefifo_ffdc_get(struct sbefifo_context *sctx, const uint8_t **ffdc, uint32_t *ffdc_len)
 {
-	*ffdc = sctx->ffdc;
+	if (sctx->ffdc_len > 0) {
+		*ffdc = sctx->ffdc;
+	}
 	*ffdc_len = sctx->ffdc_len;
 
 	return sctx->status;

--- a/libsbefifo/operation.c
+++ b/libsbefifo/operation.c
@@ -133,6 +133,10 @@ int sbefifo_parse_output(struct sbefifo_context *sctx, uint32_t cmd,
 		*out = NULL;
 	}
 
+	//if there is ffdc data for success store it in internal buffer
+	if((buflen - offset-4) > *out_len) {
+		sbefifo_ffdc_set(sctx, status_word, buf + offset, buflen - offset-4);
+	}
 	return 0;
 }
 

--- a/libsbefifo/operation.c
+++ b/libsbefifo/operation.c
@@ -25,6 +25,8 @@
 #include "libsbefifo.h"
 #include "sbefifo_private.h"
 
+static const uint16_t SBEFIFO_MAX_FFDC_SIZE = 0x8000;
+
 static int sbefifo_read(struct sbefifo_context *sctx, void *buf, size_t *buflen)
 {
 	ssize_t n;
@@ -156,10 +158,10 @@ int sbefifo_operation(struct sbefifo_context *sctx,
 		return ENOTCONN;
 
 	/*
-	 * Allocate extra memory for FFDC (SBEFIFO_MAX_FFDC_SIZE = 0x2000)
+	 * Allocate extra memory for FFDC (SBEFIFO_MAX_FFDC_SIZE = 0x8000)32kb
 	 * Use *out_len as a hint to expected reply length
 	 */
-	buflen = (*out_len + 0x2000 + 3) & ~(uint32_t)3;
+	buflen = (*out_len + SBEFIFO_MAX_FFDC_SIZE + 3) & ~(uint32_t)3;
 	buf = malloc(buflen);
 	if (!buf)
 		return ENOMEM;


### PR DESCRIPTION
1) Modify sbe chip-op operation to read FFDC data for chip-op success case so as to get FFDC data from SBE for any earlier or internal SBE failure

2) As SBE now caters for multiple FFDC packets increase the size of the memory allocated by pdbg to read the FFDC data to 32KB.