### PR TITLE
Fix the device path mapping for Everest

### DIFF
--- a/bmc-kernel-everest.dts.m4
+++ b/bmc-kernel-everest.dts.m4
@@ -240,8 +240,8 @@ define(`HMFSI_ODY',
 	HMFSI_ODY(6, 4, 5, 14)
 	HMFSI_ODY(7, 4, 5, 15)
 
-	HMFSI_ODY(0, 5, 6, 02)
-	HMFSI_ODY(1, 5, 6, 03)
+	HMFSI_ODY(0, 5, 6, 03)
+	HMFSI_ODY(1, 5, 6, 02)
 	HMFSI_ODY(2, 5, 6, 10)
 	HMFSI_ODY(3, 5, 6, 11)
 	HMFSI_ODY(4, 5, 6, 14)

--- a/bmc-sbefifo-everest.dts.m4
+++ b/bmc-sbefifo-everest.dts.m4
@@ -232,8 +232,8 @@ define(`BMC_I2CBUS',
 	HMFSI_ODY(6, 4, 5, 14)
 	HMFSI_ODY(7, 4, 5, 15)
 
-	HMFSI_ODY(0, 5, 6, 02)
-	HMFSI_ODY(1, 5, 6, 03)
+	HMFSI_ODY(0, 5, 6, 03)
+	HMFSI_ODY(1, 5, 6, 02)
 	HMFSI_ODY(2, 5, 6, 10)
 	HMFSI_ODY(3, 5, 6, 11)
 	HMFSI_ODY(4, 5, 6, 14)


### PR DESCRIPTION
putscom on odyssey -p89 called out the wrong location code, as the device path mapping for ocmb_chip-30 and ocmb_chip-31 were interchanged. This happens only on Everest system. Fixed it both for kernel and sbefifo path.

Tested and working as expected.

