### PR TITLE
Fix ocmb index value

### DIFF
--- a/bmc-kernel-everest.dts.m4
+++ b/bmc-kernel-everest.dts.m4
@@ -25,7 +25,7 @@ define(`PIB_ODY',
 		#size-cells = <0x1>;
 		reg = <0x0 0x$1 0x8000>; /*dummy to fix dts warning*/
 		compatible = "ibm,kernel-pib-ody";
-		index = <0x$1>;
+		index = <$1>;
 		proc = <0x$2>;
 		port = <$4>;
 		device-path = "/dev/scom$3$4";
@@ -149,7 +149,7 @@ define(`HMFSI_ODY',
 		compatible = "ibm,kernel-fsi-ody";
 		device-path = "/i2cr$3$4/slave@00:00/raw";
 		reg = <0x0 0x$1 0x8000>; /*dummy to fix dts warning*/
-		index = <0x$1>;
+		index = <$1>;
 		proc = <0x$2>;
 		port = <$4>;
 		system-path = "/proc$2/ocmb$1/fsi";
@@ -194,76 +194,79 @@ define(`HMFSI_ODY',
 
 	FSI_POST()
 
-	HMFSI_ODY(0, 0, 1, 00)
-	HMFSI_ODY(1, 0, 1, 01)
-	HMFSI_ODY(2, 0, 1, 10)
-	HMFSI_ODY(3, 0, 1, 11)
-	HMFSI_ODY(4, 0, 1, 12)
-	HMFSI_ODY(5, 0, 1, 13)
-	HMFSI_ODY(6, 0, 1, 14)
-	HMFSI_ODY(7, 0, 1, 15)
+// The index number, the first argument is not sequencial number
+// because in the everest device tree file, 
+// the index (physical path) which is received from MRW is such.
+	HMFSI_ODY(56, 0, 1, 00)
+	HMFSI_ODY(57, 0, 1, 01)
+	HMFSI_ODY(58, 0, 1, 10)
+	HMFSI_ODY(62, 0, 1, 11)
+	HMFSI_ODY(59, 0, 1, 12)
+	HMFSI_ODY(60, 0, 1, 13)
+	HMFSI_ODY(63, 0, 1, 14)
+	HMFSI_ODY(61, 0, 1, 15)
 
-	HMFSI_ODY(0, 1, 2, 02)
-	HMFSI_ODY(1, 1, 2, 03)
-	HMFSI_ODY(2, 1, 2, 10)
-	HMFSI_ODY(3, 1, 2, 11)
-	HMFSI_ODY(4, 1, 2, 14)
-	HMFSI_ODY(5, 1, 2, 15)
-	HMFSI_ODY(6, 1, 2, 16)
-	HMFSI_ODY(7, 1, 2, 17)
+	HMFSI_ODY(55, 1, 2, 02)
+	HMFSI_ODY(54, 1, 2, 03)
+	HMFSI_ODY(53, 1, 2, 10)
+	HMFSI_ODY(50, 1, 2, 11)
+	HMFSI_ODY(52, 1, 2, 14)
+	HMFSI_ODY(51, 1, 2, 15)
+	HMFSI_ODY(48, 1, 2, 16)
+	HMFSI_ODY(49, 1, 2, 17)
 
 
 	HMFSI_ODY(0, 2, 3, 00)
 	HMFSI_ODY(1, 2, 3, 01)
 	HMFSI_ODY(2, 2, 3, 10)
-	HMFSI_ODY(3, 2, 3, 11)
-	HMFSI_ODY(4, 2, 3, 12)
-	HMFSI_ODY(5, 2, 3, 13)
-	HMFSI_ODY(6, 2, 3, 14)
-	HMFSI_ODY(7, 2, 3, 15)
+	HMFSI_ODY(6, 2, 3, 11)
+	HMFSI_ODY(3, 2, 3, 12)
+	HMFSI_ODY(4, 2, 3, 13)
+	HMFSI_ODY(7, 2, 3, 14)
+	HMFSI_ODY(5, 2, 3, 15)
 
-	HMFSI_ODY(0, 3, 4, 02)
-	HMFSI_ODY(1, 3, 4, 03)
-	HMFSI_ODY(2, 3, 4, 10)
-	HMFSI_ODY(3, 3, 4, 11)
-	HMFSI_ODY(4, 3, 4, 14)
-	HMFSI_ODY(5, 3, 4, 15)
-	HMFSI_ODY(6, 3, 4, 16)
-	HMFSI_ODY(7, 3, 4, 17)
+	HMFSI_ODY(15, 3, 4, 02)
+	HMFSI_ODY(14, 3, 4, 03)
+	HMFSI_ODY(13, 3, 4, 10)
+	HMFSI_ODY(10, 3, 4, 11)
+	HMFSI_ODY(12, 3, 4, 14)
+	HMFSI_ODY(11, 3, 4, 15)
+	HMFSI_ODY(8, 3, 4, 16)
+	HMFSI_ODY(9, 3, 4, 17)
 
-	HMFSI_ODY(0, 4, 5, 00)
-	HMFSI_ODY(1, 4, 5, 01)
-	HMFSI_ODY(2, 4, 5, 10)
-	HMFSI_ODY(3, 4, 5, 11)
-	HMFSI_ODY(4, 4, 5, 12)
-	HMFSI_ODY(5, 4, 5, 13)
-	HMFSI_ODY(6, 4, 5, 14)
-	HMFSI_ODY(7, 4, 5, 15)
+	HMFSI_ODY(16, 4, 5, 00)
+	HMFSI_ODY(17, 4, 5, 01)
+	HMFSI_ODY(18, 4, 5, 10)
+	HMFSI_ODY(22, 4, 5, 11)
+	HMFSI_ODY(19, 4, 5, 12)
+	HMFSI_ODY(21, 4, 5, 13)
+	HMFSI_ODY(23, 4, 5, 14)
+	HMFSI_ODY(20, 4, 5, 15)
 
-	HMFSI_ODY(0, 5, 6, 03)
-	HMFSI_ODY(1, 5, 6, 02)
-	HMFSI_ODY(2, 5, 6, 10)
-	HMFSI_ODY(3, 5, 6, 11)
-	HMFSI_ODY(4, 5, 6, 14)
-	HMFSI_ODY(5, 5, 6, 15)
-	HMFSI_ODY(6, 5, 6, 16)
-	HMFSI_ODY(7, 5, 6, 17)
+	HMFSI_ODY(31, 5, 6, 03)
+	HMFSI_ODY(30, 5, 6, 02)
+	HMFSI_ODY(29, 5, 6, 10)
+	HMFSI_ODY(25, 5, 6, 11)
+	HMFSI_ODY(28, 5, 6, 14)
+	HMFSI_ODY(26, 5, 6, 15)
+	HMFSI_ODY(24, 5, 6, 16)
+	HMFSI_ODY(27, 5, 6, 17)
 
-	HMFSI_ODY(0, 6, 7, 00)
-	HMFSI_ODY(1, 6, 7, 01)
-	HMFSI_ODY(2, 6, 7, 10)
-	HMFSI_ODY(3, 6, 7, 11)
-	HMFSI_ODY(4, 6, 7, 12)
-	HMFSI_ODY(5, 6, 7, 13)
-	HMFSI_ODY(6, 6, 7, 14)
-	HMFSI_ODY(7, 6, 7, 15)
+	HMFSI_ODY(41, 6, 7, 00)
+	HMFSI_ODY(40, 6, 7, 01)
+	HMFSI_ODY(42, 6, 7, 10)
+	HMFSI_ODY(46, 6, 7, 11)
+	HMFSI_ODY(43, 6, 7, 12)
+	HMFSI_ODY(45, 6, 7, 13)
+	HMFSI_ODY(47, 6, 7, 14)
+	HMFSI_ODY(44, 6, 7, 15)
 
-	HMFSI_ODY(0, 7, 8, 02)
-	HMFSI_ODY(1, 7, 8, 03)
-	HMFSI_ODY(2, 7, 8, 10)
-	HMFSI_ODY(3, 7, 8, 11)
-	HMFSI_ODY(4, 7, 8, 14)
-	HMFSI_ODY(5, 7, 8, 15)
-	HMFSI_ODY(6, 7, 8, 16)
-	HMFSI_ODY(7, 7, 8, 17)
+	HMFSI_ODY(38, 7, 8, 02)
+	HMFSI_ODY(39, 7, 8, 03)
+	HMFSI_ODY(37, 7, 8, 10)
+	HMFSI_ODY(33, 7, 8, 11)
+	HMFSI_ODY(36, 7, 8, 14)
+	HMFSI_ODY(34, 7, 8, 15)
+	HMFSI_ODY(32, 7, 8, 16)
+	HMFSI_ODY(35, 7, 8, 17)
 };

--- a/bmc-kernel-rainier.dts.m4
+++ b/bmc-kernel-rainier.dts.m4
@@ -25,7 +25,7 @@ define(`PIB_ODY',
 		#size-cells = <0x1>;
 		reg = <0x0 0x$1 0x8000>; /*dummy to fix dts warning*/
 		compatible = "ibm,kernel-pib-ody";
-		index = <0x$1>;
+		index = <$1>;
 		proc = <0x$2>;
 		port = <$4>;
 		device-path = "/dev/scom$3$4";
@@ -149,7 +149,7 @@ define(`HMFSI_ODY',
 		compatible = "ibm,kernel-fsi-ody";
 		device-path = "/i2cr$3$4/slave@00:00/raw";
 		reg = <0x0 0x$1 0x8000>; /*dummy to fix dts warning*/
-		index = <0x$1>;
+		index = <$1>;
 		proc = <0x$2>;
 		port = <$4>;
 		system-path = "/proc$2/ocmb$1/fsi";
@@ -203,30 +203,30 @@ define(`HMFSI_ODY',
 	HMFSI_ODY(6, 0, 1, 14)
 	HMFSI_ODY(7, 0, 1, 01)
 
-	HMFSI_ODY(0, 1, 2, 02)
-	HMFSI_ODY(1, 1, 2, 10)
-	HMFSI_ODY(2, 1, 2, 14)
-	HMFSI_ODY(3, 1, 2, 17)
-	HMFSI_ODY(4, 1, 2, 15)
-	HMFSI_ODY(5, 1, 2, 11)
-	HMFSI_ODY(6, 1, 2, 03)
-	HMFSI_ODY(7, 1, 2, 16)
+	HMFSI_ODY(8, 1, 2, 02)
+	HMFSI_ODY(9, 1, 2, 10)
+	HMFSI_ODY(10, 1, 2, 14)
+	HMFSI_ODY(11, 1, 2, 17)
+	HMFSI_ODY(12, 1, 2, 15)
+	HMFSI_ODY(13, 1, 2, 11)
+	HMFSI_ODY(14, 1, 2, 03)
+	HMFSI_ODY(15, 1, 2, 16)
 
-	HMFSI_ODY(0, 2, 3, 11)
-	HMFSI_ODY(1, 2, 3, 10)
-	HMFSI_ODY(2, 2, 3, 12)
-	HMFSI_ODY(3, 2, 3, 13)
-	HMFSI_ODY(4, 2, 3, 15)
-	HMFSI_ODY(5, 2, 3, 00)
-	HMFSI_ODY(6, 2, 3, 14)
-	HMFSI_ODY(7, 2, 3, 01)
+	HMFSI_ODY(16, 2, 3, 11)
+	HMFSI_ODY(17, 2, 3, 10)
+	HMFSI_ODY(18, 2, 3, 12)
+	HMFSI_ODY(19, 2, 3, 13)
+	HMFSI_ODY(20, 2, 3, 15)
+	HMFSI_ODY(21, 2, 3, 00)
+	HMFSI_ODY(22, 2, 3, 14)
+	HMFSI_ODY(23, 2, 3, 01)
 
-	HMFSI_ODY(0, 3, 4, 02)
-	HMFSI_ODY(1, 3, 4, 10)
-	HMFSI_ODY(2, 3, 4, 14)
-	HMFSI_ODY(3, 3, 4, 17)
-	HMFSI_ODY(4, 3, 4, 15)
-	HMFSI_ODY(5, 3, 4, 11)
-	HMFSI_ODY(6, 3, 4, 03)
-	HMFSI_ODY(7, 3, 4, 16)
+	HMFSI_ODY(24, 3, 4, 02)
+	HMFSI_ODY(25, 3, 4, 10)
+	HMFSI_ODY(26, 3, 4, 14)
+	HMFSI_ODY(27, 3, 4, 17)
+	HMFSI_ODY(28, 3, 4, 15)
+	HMFSI_ODY(29, 3, 4, 11)
+	HMFSI_ODY(30, 3, 4, 03)
+	HMFSI_ODY(31, 3, 4, 16)
 };

--- a/bmc-sbefifo-everest.dts.m4
+++ b/bmc-sbefifo-everest.dts.m4
@@ -102,7 +102,7 @@ define(`HMFSI_ODY',
         compatible = "ibm,kernel-fsi-ody";
         device-path = "/i2cr$3$4/slave@00:00/raw";
         reg = <0x0 0x$1 0x8000>; /*dummy to fix dts warning*/
-        index = <0x$1>;
+        index = <$1>;
         proc = <0x$2>;
         port = <$4>;
 
@@ -120,14 +120,14 @@ define(`SBEFIFO_ODY',
 		#size-cells = <0x1>;
 		compatible = "ibm,kernel-sbefifo-ody";
 		reg = <0x0 0x$1 0x8000>; /*dummy to fix dts warning*/
-		index = <0x$1>;
+		index = <$1>;
 		proc = <0x$2>;
 		port = <$4>;
 		device-path = "/dev/sbefifo$3$4";
 
 		sbefifo-chipop-ody {
 			compatible = "ibm,sbefifo-chipop-ody";
-			index = <0x$1>;
+			index = <$1>;
 			proc = <0x$2>;
 			port = <$4>;
 		};
@@ -186,76 +186,79 @@ define(`BMC_I2CBUS',
 
 	FSI_POST()
 
-	HMFSI_ODY(0, 0, 1, 00)
-	HMFSI_ODY(1, 0, 1, 01)
-	HMFSI_ODY(2, 0, 1, 10)
-	HMFSI_ODY(3, 0, 1, 11)
-	HMFSI_ODY(4, 0, 1, 12)
-	HMFSI_ODY(5, 0, 1, 13)
-	HMFSI_ODY(6, 0, 1, 14)
-	HMFSI_ODY(7, 0, 1, 15)
+// The index number, the first argument is not sequencial number
+// because in the everest device tree file, 
+// the index (physical path) which is received from MRW is such.
+	HMFSI_ODY(56, 0, 1, 00)
+	HMFSI_ODY(57, 0, 1, 01)
+	HMFSI_ODY(58, 0, 1, 10)
+	HMFSI_ODY(62, 0, 1, 11)
+	HMFSI_ODY(59, 0, 1, 12)
+	HMFSI_ODY(60, 0, 1, 13)
+	HMFSI_ODY(63, 0, 1, 14)
+	HMFSI_ODY(61, 0, 1, 15)
 
-	HMFSI_ODY(0, 1, 2, 02)
-	HMFSI_ODY(1, 1, 2, 03)
-	HMFSI_ODY(2, 1, 2, 10)
-	HMFSI_ODY(3, 1, 2, 11)
-	HMFSI_ODY(4, 1, 2, 14)
-	HMFSI_ODY(5, 1, 2, 15)
-	HMFSI_ODY(6, 1, 2, 16)
-	HMFSI_ODY(7, 1, 2, 17)
+	HMFSI_ODY(55, 1, 2, 02)
+	HMFSI_ODY(54, 1, 2, 03)
+	HMFSI_ODY(53, 1, 2, 10)
+	HMFSI_ODY(50, 1, 2, 11)
+	HMFSI_ODY(52, 1, 2, 14)
+	HMFSI_ODY(51, 1, 2, 15)
+	HMFSI_ODY(48, 1, 2, 16)
+	HMFSI_ODY(49, 1, 2, 17)
 
 
 	HMFSI_ODY(0, 2, 3, 00)
 	HMFSI_ODY(1, 2, 3, 01)
 	HMFSI_ODY(2, 2, 3, 10)
-	HMFSI_ODY(3, 2, 3, 11)
-	HMFSI_ODY(4, 2, 3, 12)
-	HMFSI_ODY(5, 2, 3, 13)
-	HMFSI_ODY(6, 2, 3, 14)
-	HMFSI_ODY(7, 2, 3, 15)
+	HMFSI_ODY(6, 2, 3, 11)
+	HMFSI_ODY(3, 2, 3, 12)
+	HMFSI_ODY(4, 2, 3, 13)
+	HMFSI_ODY(7, 2, 3, 14)
+	HMFSI_ODY(5, 2, 3, 15)
 
-	HMFSI_ODY(0, 3, 4, 02)
-	HMFSI_ODY(1, 3, 4, 03)
-	HMFSI_ODY(2, 3, 4, 10)
-	HMFSI_ODY(3, 3, 4, 11)
-	HMFSI_ODY(4, 3, 4, 14)
-	HMFSI_ODY(5, 3, 4, 15)
-	HMFSI_ODY(6, 3, 4, 16)
-	HMFSI_ODY(7, 3, 4, 17)
+	HMFSI_ODY(15, 3, 4, 02)
+	HMFSI_ODY(14, 3, 4, 03)
+	HMFSI_ODY(13, 3, 4, 10)
+	HMFSI_ODY(10, 3, 4, 11)
+	HMFSI_ODY(12, 3, 4, 14)
+	HMFSI_ODY(11, 3, 4, 15)
+	HMFSI_ODY(8, 3, 4, 16)
+	HMFSI_ODY(9, 3, 4, 17)
 
-	HMFSI_ODY(0, 4, 5, 00)
-	HMFSI_ODY(1, 4, 5, 01)
-	HMFSI_ODY(2, 4, 5, 10)
-	HMFSI_ODY(3, 4, 5, 11)
-	HMFSI_ODY(4, 4, 5, 12)
-	HMFSI_ODY(5, 4, 5, 13)
-	HMFSI_ODY(6, 4, 5, 14)
-	HMFSI_ODY(7, 4, 5, 15)
+	HMFSI_ODY(16, 4, 5, 00)
+	HMFSI_ODY(17, 4, 5, 01)
+	HMFSI_ODY(18, 4, 5, 10)
+	HMFSI_ODY(22, 4, 5, 11)
+	HMFSI_ODY(19, 4, 5, 12)
+	HMFSI_ODY(21, 4, 5, 13)
+	HMFSI_ODY(23, 4, 5, 14)
+	HMFSI_ODY(20, 4, 5, 15)
 
-	HMFSI_ODY(0, 5, 6, 03)
-	HMFSI_ODY(1, 5, 6, 02)
-	HMFSI_ODY(2, 5, 6, 10)
-	HMFSI_ODY(3, 5, 6, 11)
-	HMFSI_ODY(4, 5, 6, 14)
-	HMFSI_ODY(5, 5, 6, 15)
-	HMFSI_ODY(6, 5, 6, 16)
-	HMFSI_ODY(7, 5, 6, 17)
+	HMFSI_ODY(31, 5, 6, 03)
+	HMFSI_ODY(30, 5, 6, 02)
+	HMFSI_ODY(29, 5, 6, 10)
+	HMFSI_ODY(25, 5, 6, 11)
+	HMFSI_ODY(28, 5, 6, 14)
+	HMFSI_ODY(26, 5, 6, 15)
+	HMFSI_ODY(24, 5, 6, 16)
+	HMFSI_ODY(27, 5, 6, 17)
 
-	HMFSI_ODY(0, 6, 7, 00)
-	HMFSI_ODY(1, 6, 7, 01)
-	HMFSI_ODY(2, 6, 7, 10)
-	HMFSI_ODY(3, 6, 7, 11)
-	HMFSI_ODY(4, 6, 7, 12)
-	HMFSI_ODY(5, 6, 7, 13)
-	HMFSI_ODY(6, 6, 7, 14)
-	HMFSI_ODY(7, 6, 7, 15)
+	HMFSI_ODY(41, 6, 7, 00)
+	HMFSI_ODY(40, 6, 7, 01)
+	HMFSI_ODY(42, 6, 7, 10)
+	HMFSI_ODY(46, 6, 7, 11)
+	HMFSI_ODY(43, 6, 7, 12)
+	HMFSI_ODY(45, 6, 7, 13)
+	HMFSI_ODY(47, 6, 7, 14)
+	HMFSI_ODY(44, 6, 7, 15)
 
-	HMFSI_ODY(0, 7, 8, 02)
-	HMFSI_ODY(1, 7, 8, 03)
-	HMFSI_ODY(2, 7, 8, 10)
-	HMFSI_ODY(3, 7, 8, 11)
-	HMFSI_ODY(4, 7, 8, 14)
-	HMFSI_ODY(5, 7, 8, 15)
-	HMFSI_ODY(6, 7, 8, 16)
-	HMFSI_ODY(7, 7, 8, 17)
+	HMFSI_ODY(38, 7, 8, 02)
+	HMFSI_ODY(39, 7, 8, 03)
+	HMFSI_ODY(37, 7, 8, 10)
+	HMFSI_ODY(33, 7, 8, 11)
+	HMFSI_ODY(36, 7, 8, 14)
+	HMFSI_ODY(34, 7, 8, 15)
+	HMFSI_ODY(32, 7, 8, 16)
+	HMFSI_ODY(35, 7, 8, 17)
 };

--- a/bmc-sbefifo-rainier.dts.m4
+++ b/bmc-sbefifo-rainier.dts.m4
@@ -102,7 +102,7 @@ define(`HMFSI_ODY',
         compatible = "ibm,kernel-fsi-ody";
         device-path = "/i2cr$3$4/slave@00:00/raw";
         reg = <0x0 0x$1 0x8000>; /*dummy to fix dts warning*/
-        index = <0x$1>;
+        index = <$1>;
         proc = <0x$2>;
         port = <$4>;
 
@@ -120,14 +120,14 @@ define(`SBEFIFO_ODY',
 		#size-cells = <0x1>;
 		compatible = "ibm,kernel-sbefifo-ody";
 		reg = <0x0 0x$1 0x8000>; /*dummy to fix dts warning*/
-		index = <0x$1>;
+		index = <$1>;
 		proc = <0x$2>;
 		port = <$4>;
 		device-path = "/dev/sbefifo$3$4";
 
 		sbefifo-chipop-ody {
 			compatible = "ibm,sbefifo-chipop-ody";
-			index = <0x$1>;
+			index = <$1>;
 			proc = <0x$2>;
 			port = <$4>;
 		};
@@ -195,30 +195,30 @@ define(`BMC_I2CBUS',
 	HMFSI_ODY(6, 0, 1, 14)
 	HMFSI_ODY(7, 0, 1, 01)
 
-	HMFSI_ODY(0, 1, 2, 02)
-	HMFSI_ODY(1, 1, 2, 10)
-	HMFSI_ODY(2, 1, 2, 14)
-	HMFSI_ODY(3, 1, 2, 17)
-	HMFSI_ODY(4, 1, 2, 15)
-	HMFSI_ODY(5, 1, 2, 11)
-	HMFSI_ODY(6, 1, 2, 03)
-	HMFSI_ODY(7, 1, 2, 16)
+	HMFSI_ODY(8, 1, 2, 02)
+	HMFSI_ODY(9, 1, 2, 10)
+	HMFSI_ODY(10, 1, 2, 14)
+	HMFSI_ODY(11, 1, 2, 17)
+	HMFSI_ODY(12, 1, 2, 15)
+	HMFSI_ODY(13, 1, 2, 11)
+	HMFSI_ODY(14, 1, 2, 03)
+	HMFSI_ODY(15, 1, 2, 16)
 
-	HMFSI_ODY(0, 2, 3, 11)
-	HMFSI_ODY(1, 2, 3, 10)
-	HMFSI_ODY(2, 2, 3, 12)
-	HMFSI_ODY(3, 2, 3, 13)
-	HMFSI_ODY(4, 2, 3, 15)
-	HMFSI_ODY(5, 2, 3, 00)
-	HMFSI_ODY(6, 2, 3, 14)
-	HMFSI_ODY(7, 2, 3, 01)
+	HMFSI_ODY(16, 2, 3, 11)
+	HMFSI_ODY(17, 2, 3, 10)
+	HMFSI_ODY(18, 2, 3, 12)
+	HMFSI_ODY(19, 2, 3, 13)
+	HMFSI_ODY(20, 2, 3, 15)
+	HMFSI_ODY(21, 2, 3, 00)
+	HMFSI_ODY(22, 2, 3, 14)
+	HMFSI_ODY(23, 2, 3, 01)
 
-	HMFSI_ODY(0, 3, 4, 02)
-	HMFSI_ODY(1, 3, 4, 10)
-	HMFSI_ODY(2, 3, 4, 14)
-	HMFSI_ODY(3, 3, 4, 17)
-	HMFSI_ODY(4, 3, 4, 15)
-	HMFSI_ODY(5, 3, 4, 11)
-	HMFSI_ODY(6, 3, 4, 03)
-	HMFSI_ODY(7, 3, 4, 16)
+	HMFSI_ODY(24, 3, 4, 02)
+	HMFSI_ODY(25, 3, 4, 10)
+	HMFSI_ODY(26, 3, 4, 14)
+	HMFSI_ODY(27, 3, 4, 17)
+	HMFSI_ODY(28, 3, 4, 15)
+	HMFSI_ODY(29, 3, 4, 11)
+	HMFSI_ODY(30, 3, 4, 03)
+	HMFSI_ODY(31, 3, 4, 16)
 };

--- a/libpdbg/ocmb.c
+++ b/libpdbg/ocmb.c
@@ -48,7 +48,7 @@ static int sbefifo_ocmb_getscom(struct ocmb *ocmb, uint64_t addr, uint64_t *valu
 		struct sbefifo_context *sctx = sbefifo->get_sbefifo_context(sbefifo);
 		uint8_t instance_id;
 
-		instance_id = pdbg_target_index(&ocmb->target) & 0xff;
+		instance_id = pdbg_target_index(&ocmb->target) & 0x0f;
 
 		return sbefifo_hw_register_get(sctx,
 						SBEFIFO_TARGET_TYPE_OCMB,
@@ -69,7 +69,7 @@ static int sbefifo_ocmb_putscom(struct ocmb *ocmb, uint64_t addr, uint64_t value
 		struct sbefifo_context *sctx = sbefifo->get_sbefifo_context(sbefifo);
 		uint8_t instance_id;
 
-		instance_id = pdbg_target_index(&ocmb->target) & 0xff;
+		instance_id = pdbg_target_index(&ocmb->target) & 0x0f;
 
 		return sbefifo_hw_register_put(sctx,
 						SBEFIFO_TARGET_TYPE_OCMB,

--- a/libpdbg/target.c
+++ b/libpdbg/target.c
@@ -506,7 +506,6 @@ int mem_write(struct pdbg_target *target, uint64_t addr, uint8_t *input, uint64_
 int ocmb_getscom(struct pdbg_target *target, uint64_t addr, uint64_t *val)
 {
 	struct ocmb *ocmb;
-
 	assert(pdbg_target_is_class(target, "ocmb") || is_child_of_ody_chip(target));
 
 	/*TODO: https://jsw.ibm.com/browse/PFEBMC-1931 
@@ -523,12 +522,10 @@ int ocmb_getscom(struct pdbg_target *target, uint64_t addr, uint64_t *val)
 		return -1;
 
 	ocmb = target_to_ocmb(target);
-
 	if (!ocmb->getscom) {
 		PR_ERROR("getscom() not implemented for the target\n");
 		return -1;
 	}
-
 	return ocmb->getscom(ocmb, addr, val);
 }
 
@@ -672,7 +669,6 @@ enum pdbg_target_status pdbg_target_probe_ody_ocmb(struct pdbg_target *target)
 			fsi_target->status = PDBG_TARGET_NONEXISTENT;
 			return PDBG_TARGET_NONEXISTENT;
 		}
-		
 		target->status = PDBG_TARGET_ENABLED;
 		sbefifo->target.status = PDBG_TARGET_ENABLED;
 		co_target->status = PDBG_TARGET_ENABLED;
@@ -869,15 +865,14 @@ struct pdbg_target *get_backend_target(const char* class,
 
 	uint32_t ocmb_proc = pdbg_target_index(pdbg_target_parent("proc",
 							ocmb));
-	uint32_t fapi_pos = 0;
-	pdbg_target_get_attribute(ocmb, "ATTR_FAPI_POS", 4, 1, &fapi_pos);
-	fapi_pos = fapi_pos % 0x8;
+	uint32_t ocmb_index = pdbg_target_index(ocmb);
+
 	struct pdbg_target *target;
 	pdbg_for_each_class_target(class, target) {
 		uint32_t index = pdbg_target_index(target);
 		uint32_t proc = 0;
 		if(!pdbg_target_u32_property(target, "proc", &proc)) {
-			if(index == fapi_pos && proc == ocmb_proc) {
+			if(index == ocmb_index && proc == ocmb_proc) {
 				return target;
 			}
 		}


### PR DESCRIPTION
The ocmb index value is currently the same as that of the OMI index. This number is not unique and it is not easy to map the index number with the inventory path of the dimm. So using the number at the end of the physical path as the index