### PR TITLE
POZ : revert avoid double memory allocation for ffdc data

### DIFF
--- a/libpdbg/sbe_api.c
+++ b/libpdbg/sbe_api.c
@@ -213,10 +213,14 @@ int sbe_dump(struct pdbg_target *target, uint8_t type, uint8_t clock,
 }
 
 int sbe_ffdc_get(struct pdbg_target *target, uint32_t *status, uint8_t **ffdc,
-			uint32_t *ffdc_len)
+				uint32_t *ffdc_len)
 {
 	if(!is_ody_ocmb_chip(target)) {
-		struct chipop *chipop = pib_to_chipop(target);
+		struct chipop *chipop;
+		const uint8_t *data = NULL;
+		uint32_t len = 0;
+
+		chipop = pib_to_chipop(target);
 		if (!chipop)
 			return -1;
 
@@ -225,10 +229,23 @@ int sbe_ffdc_get(struct pdbg_target *target, uint32_t *status, uint8_t **ffdc,
 			return -1;
 		}
 
-		*status = chipop->ffdc_get(chipop, (const uint8_t**)ffdc, ffdc_len);
+		*status = chipop->ffdc_get(chipop, &data, &len);
+		if (data && len > 0) {
+			*ffdc = malloc(len);
+			assert(*ffdc);
+			memcpy(*ffdc, data, len);
+			*ffdc_len = len;
+		} else {
+			*ffdc = NULL;
+			*ffdc_len = 0;
+		}
 	} else {
+		struct chipop_ody *chipop;
+		const uint8_t *data = NULL;
+		uint32_t len = 0;
+
 		struct pdbg_target *co_target = get_ody_chipop_target(target);
-		struct chipop_ody *chipop = target_to_chipop_ody(co_target);
+		chipop = target_to_chipop_ody(co_target);
 		if (!chipop) {
 			PR_ERROR("chipop target not found for ody ocmb chip\n");
 			return -1;
@@ -237,14 +254,21 @@ int sbe_ffdc_get(struct pdbg_target *target, uint32_t *status, uint8_t **ffdc,
 			PR_ERROR("ffdc_get() not implemented for the target\n");
 			return -1;
 		}
-
 		struct pdbg_target *fsi = get_ody_fsi_target(target);
-
 		if (!fsi) {
 			PR_ERROR("fsi target not found for ody ocmb chip\n");
 			return -1;
 		}
-		*status = chipop->ffdc_get(chipop, fsi, (const uint8_t**)ffdc, ffdc_len);
+		*status = chipop->ffdc_get(chipop, fsi, &data, &len);
+		if (data && len > 0) {
+			*ffdc = malloc(len);
+			assert(*ffdc);
+			memcpy(*ffdc, data, len);
+			*ffdc_len = len;
+		} else {
+			*ffdc = NULL;
+			*ffdc_len = 0;
+		}
 	}
 	return 0;
 }


### PR DESCRIPTION
Revert change done to avoid double memory allocation for ffdc data.

Earlier test was done with single proc which worked as expected but with multiple proc and multiple fork processes trying to read the ffdc data it is causing double free error and core dump.

Tested:
root@p10bmc:/tmp# busctl tree xyz.openbmc_project.Dump.Manager `- /xyz
  `- /xyz/openbmc_project
    `- /xyz/openbmc_project/dump
      |- /xyz/openbmc_project/dump/hostboot
      | `- /xyz/openbmc_project/dump/hostboot/entry
      |   |- /xyz/openbmc_project/dump/hostboot/entry/20000001
      |   |- /xyz/openbmc_project/dump/hostboot/entry/20000002
      |   |- /xyz/openbmc_project/dump/hostboot/entry/20000003


Change-Id: If38be58d9938b476ab39f35e69583fda28522cd4