### PR TITLE
Fix getscom on DDR4 everst system

### DIFF
--- a/libpdbg/ocmb.c
+++ b/libpdbg/ocmb.c
@@ -48,7 +48,9 @@ static int sbefifo_ocmb_getscom(struct ocmb *ocmb, uint64_t addr, uint64_t *valu
 		struct sbefifo_context *sctx = sbefifo->get_sbefifo_context(sbefifo);
 		uint8_t instance_id;
 
-		instance_id = pdbg_target_index(&ocmb->target) & 0x0f;
+		uint32_t fapi_pos = 0;
+		pdbg_target_get_attribute(&ocmb->target, "ATTR_FAPI_POS", 4, 1, &fapi_pos);
+		instance_id = fapi_pos & 0x0f;
 
 		return sbefifo_hw_register_get(sctx,
 						SBEFIFO_TARGET_TYPE_OCMB,


### PR DESCRIPTION
The index values of pdbg targets are updated to match the physical device path. So using the index value for getting the scoms shall fail. The fapi position is still connected to the OMI index. So using the fapi position to calculate the instance id in case of DDR4 system.

root@p10bmc:/tmp# getscom explorer 08012400 -all
explorer        k0:n0:s0:p00       0x0000000000000000
explorer        k0:n0:s0:p01       0x0000000000000000
explorer        k0:n0:s0:p24       0x0000000000000000
explorer        k0:n0:s0:p25       0x0000000000000000
explorer        k0:n0:s0:p32       0x0000000000000000
explorer        k0:n0:s0:p33       0x0000000000000000
explorer        k0:n0:s0:p56       0x0000000000000000
explorer        k0:n0:s0:p57       0x0000000000000000
/usr/bin/edbg getscom explorer 08012400 -all
root@p10bmc:/tmp# getscom explorer 8012810 -all
explorer        k0:n0:s0:p00       0x8122640700112820
explorer        k0:n0:s0:p01       0x8122640700112820
explorer        k0:n0:s0:p24       0x8122640700112820
explorer        k0:n0:s0:p25       0x8122640700112820
explorer        k0:n0:s0:p32       0x8122640700112820
explorer        k0:n0:s0:p33       0x8122640700112820
explorer        k0:n0:s0:p56       0x8122640700112820
explorer        k0:n0:s0:p57       0x8122640700112820
/usr/bin/edbg getscom explorer 8012810 -all
