### PR TITLE
libpdbg: Replace POWER10 with POWER for core, thread and htm

### DIFF
--- a/libpdbg/htm.c
+++ b/libpdbg/htm.c
@@ -1513,7 +1513,7 @@ DECLARE_HW_UNIT(p8_chtm);
 
 static struct htm p10_nhtm = {
 	.target = {
-		.name = "POWER10 Nest HTM",
+		.name = "POWER Nest HTM",
 		.compatible = "ibm,power10-nhtm",
 		.class = "nhtm",
 		.probe = nhtm_probe,
@@ -1528,7 +1528,7 @@ DECLARE_HW_UNIT(p10_nhtm);
 
 static struct htm p10_chtm = {
 	.target = {
-		.name = "POWER10 Core HTM",
+		.name = "POWER Core HTM",
 		.compatible = "ibm,power10-chtm",
 		.class = "chtm",
 		.probe = chtm_probe,

--- a/libpdbg/p10chip.c
+++ b/libpdbg/p10chip.c
@@ -184,7 +184,7 @@ static int p10_thread_sreset(struct thread *thread)
 
 static struct thread p10_thread = {
 	.target = {
-		.name = "POWER10 Thread",
+		.name = "POWER Thread",
 		.compatible = "ibm,power10-thread",
 		.class = "thread",
 		.probe = p10_thread_probe,
@@ -294,7 +294,7 @@ static uint64_t p10_core_translate(struct core *c, uint64_t addr)
 
 static struct core p10_core = {
 	.target = {
-		.name = "POWER10 Core",
+		.name = "POWER Core",
 		.compatible = "ibm,power10-core",
 		.class = "core",
 		.probe = p10_core_probe,


### PR DESCRIPTION
For POWER11 systems, NagDump contained POWER10 prefix for all the targets. The prefix was updated to POWER for fapi targets in earlier commit but chip targets and htm targets were missed. Modifying the prefix for core, thread and htm targets to maintain consistency.

Test Results:

Before:
 ```
 {
    "MANUAL_ISOLATION": {
      "CURRENT_STATE": "DECONFIGURED",
      "LOCATION_CODE": "Ufcs-P0-C15",
      "PHYS_PATH": "physical:sys-0/node-0/proc-1/eq-0/fc-1/core-1",
      "REASON_DESCRIPTION": "MANUAL",
      "TYPE": "POWER10 Core"
    }
```

After:
 ```
 {
    "MANUAL_ISOLATION": {
      "CURRENT_STATE": "DECONFIGURED",
      "LOCATION_CODE": "Ufcs-P0-C15",
      "PHYS_PATH": "physical:sys-0/node-0/proc-1/eq-0/fc-1/core-1",
      "REASON_DESCRIPTION": "MANUAL",
      "TYPE": "POWER Core"
    }

```
Change-Id: If4180988f2bd6417ed1e8b67ef8e5000e4bee8b5