### PR TITLE
Add errno details to journal traces

### DIFF
--- a/libpdbg/dtb.c
+++ b/libpdbg/dtb.c
@@ -98,7 +98,7 @@ static bool get_chipid(uint32_t *chip_id)
 	cfam_id_file = fopen(path, "r");
 	free(path);
 	if (!cfam_id_file) {
-		pdbg_log(PDBG_ERROR, "Unable to open CFAM ID file\n");
+		pdbg_log(PDBG_ERROR, "Unable to open CFAM ID file errno: %d\n",errno);
 		return false;
 	}
 
@@ -512,7 +512,7 @@ static void mmap_dtb(const char *file, bool readonly, struct pdbg_mfile *mfile)
 	else
 		fd = open(file, O_RDWR);
 	if (fd < 0) {
-		pdbg_log(PDBG_ERROR, "Unable to open dtb file '%s'\n", file);
+		pdbg_log(PDBG_ERROR, "Unable to open dtb file '%s' errno: %d\n", file, errno);
 		return;
 	}
 

--- a/libpdbg/kernel.c
+++ b/libpdbg/kernel.c
@@ -128,14 +128,14 @@ static void kernel_fsi_scan_devices(void)
 
 	fd = open(path, O_WRONLY | O_SYNC);
 	if (fd < 0) {
-		PR_ERROR("Unable to open %s\n", path);
+		PR_ERROR("Unable to open %s errno: %d\n", path, errno);
 		free(path);
 		return;
 	}
 
 	rc = write(fd, &one, sizeof(one));
 	if (rc < 0)
-		PR_ERROR("Unable to write to %s\n", path);
+		PR_ERROR("Unable to write to %s errno: %d\n", path, errno);
 
 	free(path);
 	close(fd);
@@ -186,7 +186,7 @@ int kernel_fsi_probe(struct pdbg_target *target)
 		}
 	}
 
-	PR_INFO("Unable to open %s\n", path);
+	PR_INFO("Unable to open %s, errno: %d \n", path, errno);
 	free(path);
 	return -1;
 }
@@ -264,7 +264,7 @@ static int kernel_pib_probe(struct pdbg_target *target)
 
 	pib->fd = open(scom_path, O_RDWR | O_SYNC);
 	if (pib->fd < 0) {
-		PR_INFO("Unable to open %s\n", scom_path);
+		PR_INFO("Unable to open %s errno: %d\n", scom_path, errno);
 		return -1;
 	}
 

--- a/libpdbg/sbefifo.c
+++ b/libpdbg/sbefifo.c
@@ -854,7 +854,7 @@ static int sbefifo_probe(struct pdbg_target *target)
 
 	rc = sbefifo_connect(sbefifo_path, proc, &sf->sf_ctx);
 	if (rc) {
-		PR_ERROR("Unable to open sbefifo driver %s\n", sbefifo_path);
+		PR_ERROR("Unable to open sbefifo driver %s errno: %d\n", sbefifo_path, rc);
 		return rc;
 	}
 


### PR DESCRIPTION
Enhanced error logging by including errno values in journal traces when file operations like open() fail. This provides more detailed diagnostics for debugging I/O issues.